### PR TITLE
Change shebang line

### DIFF
--- a/yle-dl
+++ b/yle-dl
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
Using /usr/bin/env allows this script to call Python irregardless of
where Python is installed itself, hence not hard-coding the path in
the program.

On some systems, Python 3 is the default Python interpreter and hence
using plain 'python' in the shebang line would cause an error.  It is
recommended in PEP 394 [1] to use 'python2' in shebang lines if the
program is to be run with Python 2.

[1] http://www.python.org/dev/peps/pep-0394/
