### PR TITLE
Added Ubuntu package availability info to documentation

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,7 @@ Yle: [Yle Areena], [YleX Areena] and [Elävä Arkisto].
 Installation
 ------------
 
-Ubuntu packages are available at https://launchpad.net/~hekkup/+archive/yle-dl.
+Ubuntu packages are available at https://launchpad.net/~yle-dl/+archive/release.
 
 On other systems install dependencies: rtmpdump (version 2.4
 or newer), python and pycrypto.

--- a/README.fi
+++ b/README.fi
@@ -12,7 +12,7 @@ Asennus
 -------
 
 Ubuntu-paketit löytyvät osoitteesta
-https://launchpad.net/~hekkup/+archive/yle-dl.
+https://launchpad.net/~yle-dl/+archive/release.
 
 Muissa järjestelmissä asenna vaaditut kirjastot ja ohjelmat:
 rtmpdump (2.4 tai uudempi), python ja pycrypto.


### PR DESCRIPTION
Ubuntu packages are available at
https://launchpad.net/~hekkup/+archive/yle-dl
