### PR TITLE
Change AdobeHDS default location in help texts

### DIFF
--- a/README.fi
+++ b/README.fi
@@ -34,7 +34,7 @@ install).
 
 install-adobehds:n sijaan voit myös hakea AdobeHDS.php:n osoitteesta
 https://raw.githubusercontent.com/K-S-V/Scripts/master/AdobeHDS.php
-ja kopioida sen /usr/local/bin-hakemistoon.
+ja kopioida sen /usr/local/share/yle-dl -hakemistoon.
 
 Alkaen versiosta 1.99.9 yle-dl:stä ei enää tarvitse Ylen palvelimia
 varten muunneltua kopiota rtmpdump-ohjelmasta. Aikaisemman

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make install
 
 Instead of install-adobehds you can also manually download
 https://raw.githubusercontent.com/K-S-V/Scripts/master/AdobeHDS.php
-to /usr/local/bin.
+to /usr/local/share/yle-dl.
 
 Starting from version 1.99.9 yle-dl doesn't anymore require a modified
 rtmpdump or plugin. Instead, everything is now downloadable with the

--- a/yle-dl
+++ b/yle-dl
@@ -97,7 +97,7 @@ def usage():
     log(u'                        or "best" or "worst". Not exact on HDS streams.')
     log(u'--rtmpdump path         Set path to rtmpdump binary')
     log(u'--adobehds cmd          Set command for executing AdobeHDS.php script')
-    log(u'                        Default: "php /usr/local/bin/AdobeHDS.php"')
+    log(u'                        Default: "php /usr/local/share/yle-dl/AdobeHDS.php"')
     log(u'--destdir dir           Save files to dir')
     log(u'--protocol protos       Preferred streaming protocols (comma-separated)')
     log(u'                        Supported values: rtmp and hds')


### PR DESCRIPTION
Commit https://github.com/aajanki/yle-dl/commit/ad9ef7fa40b39ec315bb51fc509af7416278966c forgot to change the AdobeHDS default location in install and help texts. This commit changes those to point to the new default location.
