### PR TITLE
Recognize new Elävä Arkisto URLs.

### DIFF
--- a/yle-dl
+++ b/yle-dl
@@ -182,7 +182,9 @@ def int_or_else(x, default):
         return default
 
 def downloader_factory(url, protocols):
-    if url.startswith('http://yle.fi/aihe/'):
+    if url.startswith('http://yle.fi/aihe/') or \
+            url.startswith('http://areena.yle.fi/26-') or \
+            url.startswith('http://arenan.yle.fi/26-'):
         return RetryingDownloader(ElavaArkistoDownloader, protocols)
     elif url.startswith('http://svenska.yle.fi/artikel/'):
         return RetryingDownloader(ArkivetDownloader, protocols)


### PR DESCRIPTION
The new Areena uses these formats in Elävä Arkisto:

    * http://areena.yle.fi/26-<meta_id>
    * http://arenan.yle.fi/26-<meta_id>

yle-dl incorrectly processes the URLs with Areena2014Downloader, which
fails with HTTP 404 error. The commit fixes this by returning
ElavaArkistoDownloader in downloader_factory for the new URLs.