### PR TITLE
Require youtube-dl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pycrypto
+youtube-dl


### PR DESCRIPTION
After installing on a fresh OS X using the README instructions:


```bash
brew install --HEAD rtmpdump
brew install homebrew/php/php55-mcrypt
pip install -r requirements.txt
```

It said:
```bash
Could not open input file: /usr/local/share/yle-dl/AdobeHDS.php
Failed to import youtube_dl
```

Adding youtube_dl to requirements and re-running `pip install -r requirements.txt` fixed it.