### PR TITLE
Fix BINDIR and DATADIR paths, uninstall $(DATADIR)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install-adobehds:
 uninstall:
 	rm -f $(BINDIR)/yle-dl
 	rm -f $(DATADIR)/AdobeHDS.php
+	-rmdir $(DATADIR)
 
 # Uninstall librtmp and plugin installed by pre-2.0 versions
 plugindir=$(prefix)/lib/librtmp/plugins

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 prefix?=/usr/local
-BINDIR=$(DESTDIR)/$(prefix)/bin
-DATADIR=$(DESTDIR)/$(prefix)/share/yle-dl
+BINDIR=$(DESTDIR)$(prefix)/bin
+DATADIR=$(DESTDIR)$(prefix)/share/yle-dl
 
 all:
 


### PR DESCRIPTION
The current Makefile BINDIR and DATADIR have an extra '/' even for the default prefix value (i.e. BINDIR expands to //usr/local/bin and DATADIR to //usr/local/share/yle-dl). The first commit makes fixes this.

The second commit sets DATADIR to be deleted when `make uninstall` is called.