### PR TITLE
Test for errors on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ after_script:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: 3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+
+python:
+ - pypy
+ - pypy3
+ - 2.6
+ - 2.7
+ - 3.2
+ - 3.3
+ - 3.4
+ - 3.5
+
+sudo: false
+
+install:
+ - pip install pyflakes
+
+script:
+ - pyflakes yle-dl
+
+after_script:
+ - pip install pep8
+ - pep8 --statistics --count yle-dl
+
+matrix:
+  fast_finish: true

--- a/yle-dl
+++ b/yle-dl
@@ -139,7 +139,7 @@ def download_page(url):
             charset = 'iso-8859-1'
 
         return unicode(content, charset, 'replace')
-    except urllib2.URLError, exc:
+    except urllib2.URLError as exc:
         log(u"Can't read %s: %s" % (url, exc))
         return None
     except ValueError:
@@ -315,7 +315,7 @@ class BackendFactory(object):
     def is_valid_hds_backend(hds_backend):
         return (hds_backend == BackendFactory.ADOBEHDSPHP or
                 hds_backend == BackendFactory.YOUTUBEDL)
-    
+
     def __init__(self, hds_backend):
         self.hds_backend = hds_backend
 
@@ -393,7 +393,7 @@ class KalturaUtils(object):
             bitrates = [fl.get('bitrate', 0) for fl in flavors]
             log(u'Available bitrates: %s, maxbitrate = %s' %
                 (bitrates, filters.maxbitrate))
-        
+
         valid_bitrates = [fl for fl in flavors
                           if fl.get('bitrate', 0) <= filters.maxbitrate]
         if not valid_bitrates and len(flavors) >= 1:
@@ -432,7 +432,7 @@ class KalturaUtils(object):
             flavors_string = m.group(1).decode('unicode_escape').replace('\n', ' ')
         except UnicodeEncodeError:
             return []
-            
+
         try:
             flavors = json.loads(flavors_string)
         except ValueError:
@@ -862,7 +862,7 @@ class Areena2014Downloader(AreenaUtils, KalturaUtils):
             selected_media = self.select_yle_media(program_info, media_id, program_id, filters)
             if not selected_media:
                 return FailedClip(pageurl, 'Media not found')
-            
+
             streamurl = self.media_streamurl(selected_media, pageurl, filters)
             subtitles = self.media_subtitles(selected_media)
 
@@ -1756,7 +1756,7 @@ def main():
             log(u'Invalid backend: ' + bn)
             sys.exit(RD_FAILED)
         backends.append(BackendFactory(bn))
-        
+
     url = encode_url_utf8(url)
     dl = downloader_factory(url, backends)
     if not dl:

--- a/yle-dl
+++ b/yle-dl
@@ -24,6 +24,7 @@ This script downloads video and audio streams from Yle Areena
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 import sys
 import urllib
 import urllib2
@@ -733,7 +734,7 @@ class Areena2014Downloader(AreenaUtils, KalturaUtils):
                 print_url = clip.streamurl.to_episode_url()
             else:
                 print_url = clip.streamurl.to_url()
-            print print_url.encode(enc, 'replace')
+            print(print_url.encode(enc, 'replace'))
             return RD_SUCCESS
 
         return self.process(print_clip_url, url, filters)
@@ -748,7 +749,7 @@ class Areena2014Downloader(AreenaUtils, KalturaUtils):
     def print_titles(self, url, filters):
         def print_clip_title(clip):
             enc = sys.getfilesystemencoding()
-            print clip.title.encode(enc, 'replace')
+            print(clip.title.encode(enc, 'replace'))
             return RD_SUCCESS
 
         return self.process(print_clip_title, url, filters)

--- a/yle-dl
+++ b/yle-dl
@@ -364,7 +364,7 @@ class AreenaUtils(object):
                             log(u'Subtitles saved to ' + filename)
                             if preferred_lang != 'all':
                                 return
-                        except IOError, exc:
+                        except IOError as exc:
                             log(u'Failed to download subtitles at %s: %s' % (sub.url, exc))
 
     def add_BOM(self, filename):
@@ -1430,7 +1430,7 @@ class ExternalDownloader(BaseDownloader):
                 # The process died before we killed it.
                 pass
             return RD_INCOMPLETE
-        except OSError, exc:
+        except OSError as exc:
             log(u'Failed to execute ' + ' '.join(args))
             log(unicode(exc.strerror, 'UTF-8', 'replace'))
             return RD_FAILED
@@ -1584,8 +1584,8 @@ class YoutubeDLHDSDump(BaseDownloader):
         try:
             if not f4mdl.download(outputfile, info):
                 return RD_FAILED
-        except urllib2.HTTPError, ex:
-            log(u'HTTP request failed: %s %s' % (ex.code, ex.reason))
+        except urllib2.HTTPError as exc:
+            log(u'HTTP request failed: %s %s' % (exc.code, exc.reason))
             return RD_FAILED
 
         if outputfile != '-':
@@ -1642,7 +1642,7 @@ class HTTPDump(BaseDownloader):
         enc = sys.getfilesystemencoding()
         try:
             urllib.urlretrieve(self.stream.to_url(), filename.encode(enc))
-        except IOError, exc:
+        except IOError as exc:
             log(u'Download failed: ' + unicode(exc.message, 'UTF-8', 'replace'))
             return RD_FAILED
 


### PR DESCRIPTION
Test for errors on Travis CI.

This runs pyflakes, which checks for things like syntax errors. If any are found, the build fails. I've fixed the problems it found, except for Python 3.2 (see below).

It also runs pep8 for things like style suggestions, but won't fail the build if any are found (a lot are found).

This gives a build report like this:
https://travis-ci.org/hugovk/yle-dl/builds/105906093

It's also run for each PR, so you can see if there's problems before merging.

Python 3.2 is allowed to fail because it's failing due to `u()` which isn't in 3.2. It could be worked around, but is Python 3.2 you'd like to support?

TODO Please enable the aajanki/yle-dl repo at https://travis-ci.org/profile , it's free for open source.