### PR TITLE
Speed up CI install of lxml: 146s -> 40s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ env:
     - ENABLE_FINLAND_TESTS=0
 
 install:
- # Speed up CI install
- # http://lxml.de/installation.html#installation
- - CFLAGS="-O0" pip install lxml
+ # Install from wheel instead of from source in setup.py to speed up CI
+ - pip install lxml
 
  - pip install pyflakes pep8
  - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ env:
     - ENABLE_FINLAND_TESTS=0
 
 install:
+ # Speed up CI install
+ # http://lxml.de/installation.html#installation
+ - CFLAGS="-O0" pip install lxml
+
  - pip install pyflakes pep8
  - python setup.py install
 


### PR DESCRIPTION
Currently the CI is very slow when installing lxml because it's building from source.

This can be improved by pip installing from a prebuilt wheel.

Before, the build took **3 min 53 sec**, with `python setup.py install` taking _146.74s_.

https://travis-ci.org/hugovk/yle-dl/builds/294484376#L515

After, the build took **2 min 25 sec**, with `python setup.py install` taking _37.94s_ and `pip install lxml` taking _2.43s_.

https://travis-ci.org/hugovk/yle-dl/builds/294595373#L517