### PR TITLE
Allow ConfigArgParse > 0.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pycryptodomex', 'requests', 'lxml', 'future', 'mini-amf',
-        'attrs >= 18.1.0, < 18.3.0', 'ConfigArgParse == 0.13.0'
+        'attrs >= 18.1.0, < 18.3.0', 'ConfigArgParse >= 0.13.0'
     ] + ssl_sni_requires,
     extras_require = {
         'youtubedl-backend': ['youtube_dl']


### PR DESCRIPTION
[ConfigArgParse 0.14.0](https://github.com/bw2/ConfigArgParse/releases/tag/0.14.0) was released recently and yle-dl works fine with it.