### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/yledl/AdobeHDS.php
+++ b/yledl/AdobeHDS.php
@@ -794,7 +794,7 @@
               while ($this->quality >= 0)
                 {
                   $key = KeyName($this->media, $this->quality);
-                  if ($key !== NULL)
+                  if ($key !== null)
                     {
                       $this->media = $this->media[$key];
                       break;


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!