### PR TITLE
Version updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 dist: xenial
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
  - 3.5
  - 3.6
  - 3.7
+ - 3.8-dev
 
 addons:
   apt:

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             'yle-dl = yledl.yledl:main'
         ]
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/yledl/timestamp.py
+++ b/yledl/timestamp.py
@@ -30,7 +30,7 @@ def parse_areena_timestamp(timestamp):
         return None
 
     timestamp = timestamp.strip()
-    if sys.version_info.major == 3:
+    if sys.version_info.major >= 3:
         parsed = parse_areena_timestamp_py3(timestamp)
     else:
         parsed = parse_areena_timestamp_py2(timestamp)


### PR DESCRIPTION
* Add `python_requires` to help pip
* Compare version as `>= 3` instead of `== 3` to prevent surprises with any future Python 4.0
* Test on Python 3.8 beta to avoid surprises
* `sudo` no longer needed for Travis https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration