### PR TITLE
Update setup.py to allow newest attrs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pycryptodomex', 'requests', 'lxml', 'future', 'mini-amf',
-        'attrs >= 18.1.0, < 19.3.0', 'ConfigArgParse >= 0.13.0'
+        'attrs >= 18.1.0', 'ConfigArgParse >= 0.13.0'
     ] + ssl_sni_requires,
     extras_require = {
         'youtubedl-backend': ['youtube_dl']


### PR DESCRIPTION
This will prevent a warning when running pip.

---

The reason for the upper limit is (https://github.com/aajanki/yle-dl/issues/163#issuecomment-418457066):

> The dependency is versioned, because attrs API changes every few versions, and yle-dl can only depend on a version that I know to be compatible.

And:

> The API changes also between minor versions.

However, the attrs project now promises not to break compatibility:

> attrs has a very strong backward compatibility policy that is inspired by the policy of the Twisted framework.
>
> Put simply, you shouldn’t ever be afraid to upgrade attrs if you’re only using its public APIs. If there will ever be a need to break compatibility, it will be announced in the Changelog and raise a `DeprecationWarning` for a year (if possible) before it’s finally really broken.

http://www.attrs.org/en/stable/backward-compatibility.html

I suggest removing the upper limit to avoid having to update it every so often, and if attrs ever breaks compatibility again, then to report it back upstream.
