### PR TITLE
Add stream and subtitle URLs to metadata

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -341,6 +341,7 @@ def test_print_metadata(simple):
                     'height': 360,
                     'width': 640,
                     'bitrate': 880,
+                    'url': 'https://example.com/video/low_quality.mp4',
                     'backends': ['ffmpeg']
                 },
                 {
@@ -348,6 +349,7 @@ def test_print_metadata(simple):
                     'height': 480,
                     'width': 640,
                     'bitrate': 964,
+                    'url': 'https://example.com/video/low_quality_2.mp4',
                     'backends': ['ffmpeg']
                 },
                 {
@@ -355,6 +357,7 @@ def test_print_metadata(simple):
                     'height': 720,
                     'width': 1280,
                     'bitrate': 1412,
+                    'url': 'https://example.com/video/medium_quality.mp4',
                     'backends': ['ffmpeg']
                 },
                 {
@@ -362,6 +365,7 @@ def test_print_metadata(simple):
                     'height': 720,
                     'width': 1280,
                     'bitrate': 1872,
+                    'url': 'https://example.com/video/medium_quality_high_bitrate.mp4',
                     'backends': ['ffmpeg']
                 },
                 {
@@ -369,6 +373,7 @@ def test_print_metadata(simple):
                     'height': 1080,
                     'width': 1920,
                     'bitrate': 2808,
+                    'url': 'https://example.com/video/high_quality.mp4',
                     'backends': ['ffmpeg']
                 }
             ],
@@ -377,6 +382,7 @@ def test_print_metadata(simple):
                 {'language': 'fin', 'category': 'käännöstekstitys'},
                 {'language': 'swe', 'category': 'käännöstekstitys'}
             ],
+            'subtitles': [],
             'region': 'Finland',
             'publish_timestamp': '2018-07-01T00:00:00+03:00',
             'expiration_timestamp': '2019-01-01T00:00:00+03:00'
@@ -404,21 +410,25 @@ def test_print_metadata_incomplete(simple):
             'flavors': [
                 {
                     'media_type': 'video',
+                    'url': 'https://example.com/video/1.mp4',
                     'backends': ['ffmpeg']
                 },
                 {
                     'media_type': 'video',
                     'height': 360,
                     'width': 640,
+                    'url': 'https://example.com/video/2.mp4',
                     'backends': ['ffmpeg']
                 },
                 {
                     'media_type': 'video',
+                    'url': 'https://example.com/video/3.mp4',
                     'backends': ['ffmpeg']
                 }
             ],
             'region': 'Finland',
-            'embedded_subtitles': []
+            'embedded_subtitles': [],
+            'subtitles': []
         }
     ]
 
@@ -453,7 +463,8 @@ def test_print_metadata_failed_clip(simple):
                     'error': failed_clip().flavors[0].streams[0].error_message
                 }
             ],
-            'embedded_subtitles': []
+            'embedded_subtitles': [],
+            'subtitles': []
         }
     ]
 

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -167,12 +167,20 @@ class Clip(object):
     def valid_flavor_meta(self, flavor):
         backends = [s.name for s in flavor.streams if s.is_valid()]
 
+        streams = flavor.streams
+        if streams and any(s.is_valid() for s in streams):
+            valid_stream = next(s for s in streams if s.is_valid())
+            url = valid_stream.stream_url()
+        else:
+            url = None
+
         meta = [
             ('media_type', flavor.media_type),
             ('height', flavor.height),
             ('width', flavor.width),
             ('bitrate', flavor.bitrate),
-            ('backends', backends)
+            ('backends', backends),
+            ('url', url)
         ]
         return self.ignore_none_values(meta)
 

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -137,7 +137,7 @@ class Clip(object):
              [{'language': x.language, 'category': x.category}
               for x in self.embedded_subtitles]),
             ('subtitles',
-             [{'language': x.lang, 'url': x.url}
+             [{'language': x.lang, 'url': x.url, 'category': x.category}
               for x in self.subtitles]),
             ('region', self.region),
             ('publish_timestamp',
@@ -459,13 +459,28 @@ class AreenaPreviewApiParser(object):
                 {})
 
     def subtitles(self):
+        langname2to3 = {
+            'fi': 'fin',
+            'sv': 'swe',
+            'se': 'smi',
+            'en': 'eng',
+        }
         sobj = self.ongoing().get('subtitles', [])
         subtitles = []
         for s in sobj:
-            lang = s.get('lang', None)
+            lcode = s.get('lang', None)
+            if lcode and lcode == 'fih':
+                lang = 'fin'
+                category = 'ohjelmatekstitys'
+            elif lcode:
+                lang = langname2to3.get(lcode, lcode)
+                category = 'käännöstekstitys'
+            else:
+                lang = 'unk'
+                category = 'käännöstekstitys'
             url = s.get('uri', None)
             if lang and url:
-                subtitles.append(Subtitle(url, lang))
+                subtitles.append(Subtitle(url, lang, category))
         return subtitles
 
 

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -137,7 +137,7 @@ class Clip(object):
              [{'language': x.language, 'category': x.category}
               for x in self.embedded_subtitles]),
             ('subtitles',
-             [{'lang': x.lang, 'url': x.url}
+             [{'language': x.lang, 'url': x.url}
               for x in self.subtitles]),
             ('region', self.region),
             ('publish_timestamp',

--- a/yledl/subtitles.py
+++ b/yledl/subtitles.py
@@ -8,6 +8,7 @@ import attr
 class Subtitle(object):
     url = attr.ib()
     lang = attr.ib()
+    category = attr.ib()
 
 
 @attr.s


### PR DESCRIPTION
These changes modify the output of --showmetadata option to add the stream URL for each flavor and a 'subtitles' key with language code and an URL for each available subtitle.

This makes it easier for other tools to download streams and subs from Areena. An extractor for youtube-dl using the output is here: https://github.com/tpikonen/youtube-dl/tree/yledl