### PR TITLE
Added full_title variable in output template that does not remove series name from title

### DIFF
--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -28,6 +28,7 @@ class TitleFormatter(object):
         values = {
             'series': series_title or '',
             'title': main_title,
+            'full_title': title,
             'episode': self._episode_number(season, episode),
             'timestamp': self._timestamp_string(publish_timestamp),
             'date': self._date_string(publish_timestamp),

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -121,6 +121,8 @@ def arg_parser():
                           'The template supports following substitutions: '
                           '${title} is replaced by the title of the episode, '
                           '${series} is the series title, '
+                          '${full_title} is the episode title, including the series '
+                          'name if applicable, '
                           '${episode} is the season and episode number ("S02E12"), '
                           '${timestamp} is stream publish timestamp ("2018-12-01T18:30"), '
                           '${date} is the stream publish date ("2018-12-01"), '


### PR DESCRIPTION
Some episode titles are meant to include the series name. An example is the first episode of Rölli, ["Rölli ja Robotti Ruttunen"](https://areena.yle.fi/1-736890). Using `${title}` in the output separator returns `ja Robotti Ruttunen` for this episode since the series name is removed. `${full_title}` returns `Rölli ja Robotti Ruttunen` as shown on the Yle page. The `--output-template` help message has been updated to include `${full_title}`.