### PR TITLE
Added X-Forwarded-For header to bypass region restrictions

### DIFF
--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -9,6 +9,7 @@ import platform
 import signal
 import shlex
 import subprocess
+from . import config
 from builtins import str
 from .exitcodes import RD_SUCCESS, RD_FAILED, RD_INCOMPLETE, \
     RD_SUBPROCESS_EXECUTE_FAILED
@@ -349,6 +350,7 @@ class HLSBackend(ExternalDownloader):
 
     def ffmpeg_command_line(self, clip, io, output_options):
         args = [io.ffmpeg_binary, '-y',
+                '-headers', 'X-Forwarded-For: %s\r\n' % config._x_forwarded_for_ip_address,
                 '-loglevel', ffmpeg_loglevel(logger.getEffectiveLevel()),
                 '-thread_queue_size', '1024',
                 '-seekable', '0', # needed for media ID 67-xxxx streams

--- a/yledl/config.py
+++ b/yledl/config.py
@@ -1,0 +1,1 @@
+_x_forwarded_for_ip_address = None

--- a/yledl/http.py
+++ b/yledl/http.py
@@ -6,6 +6,7 @@ import lxml.etree
 import re
 import requests
 import sys
+from . import config
 from requests.adapters import HTTPAdapter
 from .version import version
 
@@ -111,6 +112,7 @@ class HttpClient(object):
 def yledl_headers():
     headers = requests.utils.default_headers()
     headers.update({'User-Agent': yledl_user_agent()})
+    headers.update({'X-Forwarded-For': config._x_forwarded_for_ip_address})
     return headers
 
 

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -30,6 +30,9 @@ import codecs
 import logging
 import os.path
 import configargparse
+import ipaddress
+import random
+from . import config
 from urllib.parse import urlparse, urlunparse, parse_qs, quote
 from .backends import Backends
 from .downloader import YleDlDownloader
@@ -399,6 +402,9 @@ def main(argv=sys.argv):
     parser = arg_parser()
     args = parser.parse_args(argv[1:])
     set_log_level(args)
+
+    elisa_ipv4_range = list(ipaddress.ip_network('91.152.0.0/13').hosts())
+    config._x_forwarded_for_ip_address = str(random.choice(elisa_ipv4_range))
 
     urls = get_urls(args)
     if not urls:


### PR DESCRIPTION
This implements the basic region restriction bypass that @eevvoor mentioned in #267. A random IP address from an Elisa subnet identified by the youtube-dl developers is chosen, and that IP address is added to a new `X-Forwarded-For` header in `yledl_headers()` and as an argument to `ffmpeg`. This allowed me to successfully download [a Rölli episode](https://areena.yle.fi/1-736890) that is only available in Finland.

The `--geoblocked` tests are still failing even with these changes in place. I believe that this is because those tests only test live TV streams which probably do not have the new header yet. I am currently unsure of where else the `X-Forwarded-For` header should be added to handle these tests and other content. I will continue working on this, but I would appreciate any advice or info since I have not read most of the code yet.