### PR TITLE
Add geographic restriction bypass to wget backend

### DIFF
--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -481,6 +481,7 @@ class WgetBackend(ExternalDownloader):
             '-O', output_filename,
             '--no-use-server-timestamps',
             '--user-agent=' + spoofed_user_agent,
+            '--header', 'X-Forwarded-For: %s' % config._x_forwarded_for_ip_address,
             '--timeout=20'
         ]
 


### PR DESCRIPTION
This allows users to bypass geographic restrictions when using wget backend (PR #283 already added bypass to HLS backend).