### PR TITLE
Output template with subdirectory

### DIFF
--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -27,6 +27,8 @@ class YleDlDownloader(object):
             downloader.warn_on_unsupported_feature(io)
 
             outputfile = self.generate_output_name(clip.title, downloader, io)
+            if not outputfile:
+                return (RD_FAILED, None)
             if self.should_skip_downloading(outputfile, downloader, clip, io):
                 logger.info('{} has already been downloaded.'.format(outputfile))
                 return (RD_SUCCESS, outputfile)

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -63,6 +63,7 @@ class IOContext(object):
     ffmpeg_binary = attr.ib(default='ffmpeg', converter=ffmpeg_default)
     ffprobe_binary = attr.ib(default='ffprobe', converter=ffprobe_default)
     wget_binary = attr.ib(default='wget', converter=wget_default)
+    create_dirs = attr.ib(default=False)
 
     def ffprobe(self):
         if self.ffprobe_binary is None:
@@ -96,6 +97,15 @@ class OutputFileNameGenerator(object):
             path = self._filename_from_title(
                 sanitized_title, destdir, extension)
             path = self._impose_maximum_filename_length(path)
+
+        dir, _ = os.path.split(path)
+        if not os.path.exists(dir):
+            if not io.create_dirs:
+                logger.error('Directory "{}" does not exist. '
+                             'Use --create-dirs to automatically create.'.format(dir))
+                return None
+            logger.info('Creating directory "{}"'.format(dir))
+            os.makedirs(dir)
 
         return path
 

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -86,7 +86,6 @@ class OutputFileNameGenerator(object):
     def filename(self, title, extension, io):
         """Select a filename for the output."""
 
-        sanitized_title = sane_filename(title, io.excludechars)
         forced_name = io.outputfilename
         destdir = io.destdir
 
@@ -94,6 +93,13 @@ class OutputFileNameGenerator(object):
             path = self._filename_from_template(
                 forced_name, destdir, extension)
         else:
+            if '/' in title:
+                # Title contains a subdirectory
+                path, title = title.rsplit('/', maxsplit=1)
+                destdir = destdir or ''
+                for subdir in path.split('/'):
+                    destdir = os.path.join(destdir, subdir)
+            sanitized_title = sane_filename(title, io.excludechars)
             path = self._filename_from_title(
                 sanitized_title, destdir, extension)
             path = self._impose_maximum_filename_length(path)

--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -162,7 +162,7 @@ class Substitution(object):
     def substitute(self, values):
         key = self.variable_name[2:-1]
         val = values.get(key, self.variable_name)
-        return val if val else ''
+        return val.replace('/', '_') if val else ''
 
 
 class Literal(object):

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -135,6 +135,8 @@ def arg_parser():
     io_group.add_argument('--destdir', metavar='DIR',
                           type=str,
                           help='Save files to DIR')
+    io_group.add_argument('--create-dirs', action='store_true',
+                          help='Create directories automatically.')
     action_group = io_group.add_mutually_exclusive_group()
     action_group.add_argument('--showurl', action='store_true',
                               help="Print URL, don't download")
@@ -423,7 +425,8 @@ def main(argv=sys.argv):
                    args.resume, args.overwrite, dl_limits, excludechars,
                    args.proxy, random_elisa_ipv4(), args.sublang,
                    args.metadatalang, args.postprocess,
-                   args.ffmpeg, args.ffprobe, args.wget)
+                   args.ffmpeg, args.ffprobe, args.wget,
+                   args.create_dirs)
 
     if args.showurl:
         action = StreamAction.PRINT_STREAM_URL

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -128,6 +128,7 @@ def arg_parser():
                           '${date} is the stream publish date ("2018-12-01"), '
                           '${program_id} is an unique ID, '
                           '$$ is an escape and will be replaced by a literal $. '
+                          '/ specifies a subdirectory. '
                           'Everything else will appear as-is.')
     io_group.add_argument('--pipe', action='store_true',
                           help='Dump stream to stdout for piping to media '


### PR DESCRIPTION
This allows to specify subdirectories with the output template definition using
'/'.  Nested subdirectories are also supported. A flag `--create-dirs`
is added to automatically create missing directories.

For example: `--output-template '${series}/${title} --create-dirs` will store
files as `${title}` to subdirectories defined by the `${series}` metadata.