### PR TITLE
Modernize code style somewhat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ import re
 import sys
 from setuptools import setup
 
-needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 maybe_pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 long_description = \
-u"""\
+"""\
 yle-dl is a tool for downloading media files from the video streaming
 services of the Finnish national broadcasting company Yle: Yle
 Areena, Elävä Arkisto and Yle news.

--- a/tests/integration/test_arkivet_it.py
+++ b/tests/integration/test_arkivet_it.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from utils import fetch_title, fetch_stream_url, fetch_metadata
 
 def test_arkivet_title():

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -31,7 +31,7 @@ class StateCollectingBackend(BaseDownloader):
         return RD_SUCCESS
 
     def stream_url(self):
-        return 'https://example.com/video/{}.mp4'.format(self.id)
+        return f'https://example.com/video/{self.id}.mp4'
 
     def next_available_filename(self, proposed):
         return proposed
@@ -51,7 +51,7 @@ class FailingBackend(StateCollectingBackend):
         return RD_FAILED
 
 
-class MockGeoLocation(object):
+class MockGeoLocation:
     def located_in_finland(self, referrer):
         return True
 
@@ -189,7 +189,7 @@ def failed_stream_clip(state_dict):
 
 
 @attr.s
-class DownloaderParametersFixture(object):
+class DownloaderParametersFixture:
     io = attr.ib()
     filters = attr.ib()
     downloader = attr.ib()

--- a/tests/test_flavor_filters.py
+++ b/tests/test_flavor_filters.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-
 from yledl import YleDlDownloader, StreamFilters
 from yledl.backends import Backends, FailingBackend
 from yledl.streamflavor import StreamFlavor, FailedFlavor
 
 
-class MockBackend(object):
+class MockBackend:
     def __init__(self, name, data=None):
         self.name = name
         self.data = data
@@ -14,7 +12,7 @@ class MockBackend(object):
         return True
 
 
-class MockGeoLocation(object):
+class MockGeoLocation:
     def located_in_finland(self, referrer):
         return True
 

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from datetime import datetime, timedelta
 from yledl.timestamp import parse_areena_timestamp
 

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -117,8 +117,7 @@ class BaseDownloader:
         try:
             downloaded_duration = ffprobe.duration_seconds_file(filename)
         except ValueError as ex:
-            logger.warning('Failed to get duration for the file'
-                           '{}: {}'.format(filename, str(ex)))
+            logger.warning(f'Failed to get duration for the file{filename}: {str(ex)}')
             return False
 
         logger.debug('Downloaded duration {} s, expected {} s'.format(
@@ -374,7 +373,7 @@ class HLSBackend(ExternalDownloader):
     def input_args(self, io):
         args = [
             '-y',
-            '-headers', 'X-Forwarded-For: %s\r\n' % io.x_forwarded_for,
+            '-headers', f'X-Forwarded-For: {io.x_forwarded_for}\r\n',
             '-loglevel', ffmpeg_loglevel(logger.getEffectiveLevel()),
             '-thread_queue_size', '2048',
             '-seekable', '0',  # needed for media ID 67-xxxx streams
@@ -538,7 +537,7 @@ class WgetBackend(ExternalDownloader):
             '-O', output_filename,
             '--no-use-server-timestamps',
             '--user-agent=' + spoofed_user_agent,
-            '--header', 'X-Forwarded-For: %s' % io.x_forwarded_for,
+            '--header', f'X-Forwarded-For: {io.x_forwarded_for}',
             '--timeout=20'
         ]
 

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -106,9 +106,7 @@ class BaseDownloader:
         if not ffprobe or not os.path.exists(filename):
             return False
 
-        logger.info('{} already exists.\n'
-                    'Checking if the stream is complete...'
-                    .format(filename))
+        logger.info(f'{filename} already exists.\nChecking if the stream is complete...')
 
         expected_duration = clip.duration_seconds
         if expected_duration is None or expected_duration <= 0:
@@ -117,11 +115,10 @@ class BaseDownloader:
         try:
             downloaded_duration = ffprobe.duration_seconds_file(filename)
         except ValueError as ex:
-            logger.warning(f'Failed to get duration for the file{filename}: {str(ex)}')
+            logger.warning(f'Failed to get duration for the file{filename}: {ex}')
             return False
 
-        logger.debug('Downloaded duration {} s, expected {} s'.format(
-            downloaded_duration, expected_duration))
+        logger.debug(f'Downloaded duration {downloaded_duration} s, expected {expected_duration} s')
 
         return downloaded_duration >= 0.98 * expected_duration
 

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import ctypes
 import ctypes.util
 import logging
@@ -9,7 +7,6 @@ import platform
 import signal
 import shlex
 import subprocess
-from builtins import str
 from .exitcodes import RD_SUCCESS, RD_FAILED, RD_INCOMPLETE, \
     RD_SUBPROCESS_EXECUTE_FAILED
 from .http import HttpClient
@@ -20,21 +17,21 @@ from .utils import ffmpeg_loglevel
 logger = logging.getLogger('yledl')
 
 
-class IOCapability(object):
+class IOCapability:
     RESUME = 'resume'
     PROXY = 'proxy'
     RATELIMIT = 'ratelimit'
     SLICE = 'slice'
 
 
-class PreferredFileExtension(object):
+class PreferredFileExtension:
     def __init__(self, extension):
         assert extension.startswith('.')
         self.extension = extension
         self.is_mandatory = False
 
 
-class MandatoryFileExtension(object):
+class MandatoryFileExtension:
     def __init__(self, extension):
         assert extension.startswith('.')
         self.extension = extension
@@ -52,7 +49,7 @@ def shlex_join(elements):
 ### Base class for downloading a stream to a local file ###
 
 
-class BaseDownloader(object):
+class BaseDownloader:
     def __init__(self):
         self.io_capabilities = frozenset()
         self.error_message = None
@@ -158,7 +155,7 @@ class ExternalDownloader(BaseDownloader):
         return Subprocess().execute(commands, env)
 
 
-class Subprocess(object):
+class Subprocess:
     def execute(self, commands, extra_environment):
         """Start external processes connected with pipes and wait completion.
 
@@ -459,7 +456,7 @@ class WgetBackend(ExternalDownloader):
         self.url = url
 
         if not file_extension:
-            logger.warning('Mandatory file extension is missing for URL {}'.format(url))
+            logger.warning(f'Mandatory file extension is missing for URL {url}')
         self._file_extension = MandatoryFileExtension(file_extension or '')
         self.io_capabilities = frozenset([
             IOCapability.RESUME,
@@ -475,7 +472,7 @@ class WgetBackend(ExternalDownloader):
         if clip is not None:
             self.download_external_subtitles(clip.subtitles, output_name, io)
 
-        res = super(WgetBackend, self).save_stream(output_name, clip, io)
+        res = super().save_stream(output_name, clip, io)
         if res != 0 and logger.getEffectiveLevel() >= logging.ERROR:
             logger.error('wget failed! Increase verbosity to see more details.')
 
@@ -490,7 +487,7 @@ class WgetBackend(ExternalDownloader):
             sub = next((s for s in subtitles if s.lang == io.subtitles), None)
 
         if sub:
-            logger.debug('Downloading subtitles for {}'.format(sub.lang))
+            logger.debug(f'Downloading subtitles for {sub.lang}')
 
             destination_file = os.path.splitext(video_file_name)[0] + '.srt'
             HttpClient(io).download_to_file(sub.url, destination_file)
@@ -519,7 +516,7 @@ class WgetBackend(ExternalDownloader):
         if io.resume:
             args.append('--continue')
         if io.download_limits.ratelimit:
-            args.append('--limit-rate={}k'.format(io.download_limits.ratelimit))
+            args.append(f'--limit-rate={io.download_limits.ratelimit}k')
         args.append(self.url)
         return args
 
@@ -576,7 +573,7 @@ class FailingBackend(BaseDownloader):
         return RD_FAILED
 
 
-class Backends(object):
+class Backends:
     FFMPEG = 'ffmpeg'
     WGET = 'wget'
 

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -78,7 +78,8 @@ class BaseDownloader:
         # are trying to resume a partial download
 
     def warn_on_unsupported_resume(self, filename, clip, io):
-        if (io.resume and
+        if (
+            io.resume and
             IOCapability.RESUME not in self.io_capabilities and
             filename != '-' and
             os.path.isfile(filename)
@@ -371,11 +372,13 @@ class HLSBackend(ExternalDownloader):
         return self.external_downloader(commands, env)
 
     def input_args(self, io):
-        args = ['-y',
-                '-headers', 'X-Forwarded-For: %s\r\n' % io.x_forwarded_for,
-                '-loglevel', ffmpeg_loglevel(logger.getEffectiveLevel()),
-                '-thread_queue_size', '2048',
-                '-seekable', '0'] # needed for media ID 67-xxxx streams
+        args = [
+            '-y',
+            '-headers', 'X-Forwarded-For: %s\r\n' % io.x_forwarded_for,
+            '-loglevel', ffmpeg_loglevel(logger.getEffectiveLevel()),
+            '-thread_queue_size', '2048',
+            '-seekable', '0',  # needed for media ID 67-xxxx streams
+        ]
         if not (io.subtitles == 'none' or self.live):
             # needed for decoding webvtt subtitles
             #

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -182,7 +182,7 @@ class Subprocess:
                 pass
             return RD_INCOMPLETE
         except OSError as exc:
-            logger.error('Failed to execute ' + shell_command_string)
+            logger.error(f'Failed to execute {shell_command_string}')
             logger.error(exc.strerror)
             return RD_SUBPROCESS_EXECUTE_FAILED
 
@@ -290,12 +290,16 @@ class HLSBackend(ExternalDownloader):
         metadata = []
         if clip.description:
             metadata_spec = '' if self._is_mp4(io) else ':s:v:0'
-            metadata += ['-metadata' + metadata_spec,
-                         'description=' + clip.description]
+            metadata += [
+                f'-metadata{metadata_spec}',
+                f'description={clip.description}',
+            ]
 
         if clip.publish_timestamp:
-            metadata += ['-metadata',
-                         'creation_time=' + clip.publish_timestamp.isoformat()]
+            metadata += [
+                '-metadata',
+                f'creation_time={clip.publish_timestamp.isoformat()}',
+            ]
 
         return metadata
 
@@ -410,7 +414,7 @@ class HLSBackend(ExternalDownloader):
              '-vcodec', 'copy',
              '-acodec', 'copy',
              '-dn',
-             'file:' + output_name]
+             f'file:{output_name}']
         )
 
     def stream_url(self):
@@ -434,7 +438,7 @@ class HLSAudioBackend(HLSBackend):
             self._metadata_args(clip, io) +
             ['-acodec', 'copy',
              '-f', 'mp3',
-             'file:' + output_name]
+             f'file:{output_name}']
         )
 
     def output_args_pipe(self, io):
@@ -487,8 +491,8 @@ class WgetBackend(ExternalDownloader):
 
         if sub:
             logger.debug(f'Downloading subtitles for {sub.lang}')
-
-            destination_file = os.path.splitext(video_file_name)[0] + '.srt'
+            basename = os.path.splitext(video_file_name)[0]
+            destination_file = f'{basename}.srt'
             HttpClient(io).download_to_file(sub.url, destination_file)
 
     def build_args(self, output_name, clip, io):
@@ -533,7 +537,7 @@ class WgetBackend(ExternalDownloader):
             io.wget_binary,
             '-O', output_filename,
             '--no-use-server-timestamps',
-            '--user-agent=' + spoofed_user_agent,
+            f'--user-agent={spoofed_user_agent}',
             '--header', f'X-Forwarded-For: {io.x_forwarded_for}',
             '--timeout=20'
         ]
@@ -590,7 +594,7 @@ class Backends:
         backends = []
         for bn in backend_names:
             if not Backends.is_valid_backend(bn):
-                logger.warning('Invalid backend: ' + bn)
+                logger.warning(f'Invalid backend: {bn}')
                 continue
 
             if bn not in backends:

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -259,9 +259,9 @@ class YleDlDownloader:
     def log_output_file(self, outputfile, done=False):
         if outputfile and outputfile != '-':
             if done:
-                logger.info('Stream saved to ' + outputfile)
+                logger.info(f'Stream saved to {outputfile}')
             else:
-                logger.info('Output file: ' + outputfile)
+                logger.info(f'Output file: {outputfile}')
 
     def remove_retry_file(self, filename):
         if filename and os.path.isfile(filename):

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -12,7 +12,7 @@ from .streamflavor import FailedFlavor
 logger = logging.getLogger('yledl')
 
 
-class YleDlDownloader(object):
+class YleDlDownloader:
     def __init__(self, geolocation):
         self.geolocation = geolocation
 
@@ -30,7 +30,7 @@ class YleDlDownloader(object):
             if not outputfile:
                 return (RD_FAILED, None)
             if self.should_skip_downloading(outputfile, downloader, clip, io):
-                logger.info('{} has already been downloaded.'.format(outputfile))
+                logger.info(f'{outputfile} has already been downloaded.')
                 return (RD_SUCCESS, outputfile)
 
             self.log_output_file(outputfile)
@@ -125,7 +125,7 @@ class YleDlDownloader(object):
                     self.remove_retry_file(output_file)
                     output_file = None
 
-                logger.debug('Now trying downloader {}'.format(stream.name))
+                logger.debug(f'Now trying downloader {stream.name}')
 
                 (latest_result, output_file) = streamfunc(clip, stream)
                 if needs_retry(latest_result):
@@ -152,7 +152,7 @@ class YleDlDownloader(object):
 
         if filtered:
             selected = filtered[-1]
-            logger.debug('Selected flavor: {}'.format(selected))
+            logger.debug(f'Selected flavor: {selected}')
         else:
             selected = None
 

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -19,8 +19,7 @@ class YleDlDownloader:
     def download_clips(self, clips, io, filters):
         def download(clip, downloader):
             if not downloader:
-                logger.error('Downloading the stream at %s is not yet '
-                             'supported.' % clip.webpage)
+                logger.error(f'Downloading the stream at {clip.webpage} is not yet supported.')
                 logger.error('Try --showurl')
                 return RD_FAILED
 
@@ -63,8 +62,7 @@ class YleDlDownloader:
     def pipe(self, clips, io, filters):
         def pipe_clip(clip, downloader):
             if not downloader:
-                logger.error('Downloading the stream at %s is not yet '
-                             'supported.' % clip.webpage)
+                logger.error(f'Downloading the stream at {clip.webpage} is not yet supported.')
                 return RD_FAILED
             downloader.warn_on_unsupported_feature(io)
             res = downloader.pipe(io)
@@ -227,8 +225,7 @@ class YleDlDownloader:
                           for fl in flavors]
 
         if supported_backends:
-            msg = ('Required backend not enabled. Try: --backend {}'
-                   .format(','.join(supported_backends)))
+            msg = (f'Required backend not enabled. Try: --backend {",".join(supported_backends)}')
         elif error_messages:
             msg = error_messages[0]
         else:

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -101,8 +101,7 @@ class YleDlDownloader:
                 logger.error('No stream found')
                 overall_status = RD_FAILED
             elif all(not stream.is_valid() for stream in streams):
-                logger.error('Unsupported stream: %s' %
-                             streams[0].error_message)
+                logger.error(f'Unsupported stream: {streams[0].error_message}')
                 self.print_geo_warning(clip)
 
                 overall_status = RD_FAILED

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -253,7 +253,8 @@ class YleDlDownloader:
             return None
 
     def print_geo_warning(self, clip):
-        if (clip.region in ['Finland', None] and
+        if (
+            clip.region in ['Finland', None] and
             not self.geolocation.located_in_finland(clip.webpage)
         ):
             logger.error('This clip is only available in Finland '

--- a/yledl/exitcodes.py
+++ b/yledl/exitcodes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Public exit codes
 RD_SUCCESS = 0
 RD_FAILED = 1

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -229,7 +229,7 @@ class AreenaPlaylist(ClipExtractor):
             logger.error('Failed to parse a playlist')
             playlist = []
         elif playlist:
-            logger.debug('playlist page with %d clips' % len(playlist))
+            logger.debug(f'playlist page with {len(playlist)} clips')
         else:
             logger.debug('not a playlist')
             playlist = [url]
@@ -943,7 +943,7 @@ class YleUutisetExtractor(AreenaExtractor):
         data_ids.extend(block.get('id') for block in content
                         if block.get('type') == 'AudioBlock' and block.get('id'))
 
-        logger.debug('Found Areena data IDs: {}'.format(','.join(data_ids)))
+        logger.debug(f"Found Areena data IDs: {','.join(data_ids)}")
 
         playlist = [self.id_to_areena_url(id) for id in data_ids]
         if latest_only:

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -303,7 +303,7 @@ class AreenaPlaylist(ClipExtractor):
 
         playlist_data = playlist.get('data', [])
         episode_ids = (x['id'] for x in playlist_data if 'id' in x)
-        return ['https://areena.yle.fi/' + x for x in episode_ids]
+        return [f'https://areena.yle.fi/{episode_id}' for episode_id in episode_ids]
 
     def playlist_url(self, series_id, sort_order, page_size=100, offset=0):
         offset_param = f'&offset={str(offset)}' if offset else ''
@@ -633,7 +633,7 @@ class AreenaExtractor(AreenaPlaylist):
             info = None
         else:
             info = jsonhelpers.load_json(self.program_info_url(pid), self.httpclient)
-            logger.debug('program data:\n' + json.dumps(info, indent=2))
+            logger.debug(f'program data:\n{json.dumps(info, indent=2)}')
 
         publish_timestamp = (self.publish_timestamp(info) or
                              preview.timestamp())
@@ -711,7 +711,7 @@ class AreenaExtractor(AreenaPlaylist):
                 preview_json = []
             else:
                 raise
-        logger.debug('preview data:\n' + json.dumps(preview_json, indent=2))
+        logger.debug(f'preview data:\n{json.dumps(preview_json, indent=2)}')
 
         return AreenaPreviewApiParser(preview_json)
 
@@ -877,7 +877,7 @@ class ElavaArkistoExtractor(AreenaExtractor):
         if latest_only:
             ids = ids[-1:]
 
-        return ['https://areena.yle.fi/' + x for x in ids]
+        return [f'https://areena.yle.fi/{x}' for x in ids]
 
     def get_dataids(self, url):
         tree = self.httpclient.download_html_tree(url)
@@ -896,7 +896,7 @@ class ElavaArkistoExtractor(AreenaExtractor):
     def _simple_dataids(self, tree):
         dataids = tree.xpath("//article[@id='main-content']//div/@data-id")
         dataids = [str(d) for d in dataids]
-        return [d if '-' in d else '1-' + d for d in dataids]
+        return [d if '-' in d else f'1-{d}' for d in dataids]
 
     def _ydd_dataids(self, tree):
         player_props = [
@@ -958,5 +958,5 @@ class YleUutisetExtractor(AreenaExtractor):
         if '-' in data_id:
             areena_id = data_id
         else:
-            areena_id = '1-' + data_id
-        return 'https://areena.yle.fi/' + areena_id
+            areena_id = f'1-{data_id}'
+        return f'https://areena.yle.fi/{areena_id}'

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -24,24 +24,24 @@ def extractor_factory(url, filters, language_chooser, httpclient):
     if re.match(r'^https?://yle\.fi/aihe/', url) or \
        re.match(r'^https?://svenska\.yle\.fi/artikel/', url) or \
        re.match(r'^https?://svenska\.yle\.fi/a/', url):
-        logger.debug('{} is an Elava Arkisto URL'.format(url))
+        logger.debug(f'{url} is an Elava Arkisto URL')
         return ElavaArkistoExtractor(language_chooser, httpclient)
     elif (re.match(r'^https?://areena\.yle\.fi/audio/ohjelmat/[-a-zA-Z0-9]+', url) or
           re.match(r'^https?://areena\.yle\.fi/radio/suorat/[-a-zA-Z0-9]+', url)):
-        logger.debug('{} is a live radio URL'.format(url))
+        logger.debug(f'{url} is a live radio URL')
         return AreenaLiveRadioExtractor(language_chooser, httpclient)
     elif re.match(r'^https?://(areena|arenan)\.yle\.fi/audio/[-0-9]+', url):
-        logger.debug('{} is an audio URL'.format(url))
+        logger.debug(f'{url} is an audio URL')
         return AreenaAudio2020Extractor(language_chooser, httpclient)
     elif re.match(r'^https?://yle\.fi/(uutiset|urheilu|saa)/', url):
-        logger.debug('{} is a news URL'.format(url))
+        logger.debug(f'{url} is a news URL')
         return YleUutisetExtractor(language_chooser, httpclient)
     elif (re.match(r'^https?://(areena|arenan)\.yle\.fi/', url) or
           re.match(r'^https?://yle\.fi/', url)):
-        logger.debug('{} is an Areena URL'.format(url))
+        logger.debug(f'{url} is an Areena URL')
         return AreenaExtractor(language_chooser, httpclient)
     else:
-        logger.debug('{} is an unrecognized URL'.format(url))
+        logger.debug(f'{url} is an unrecognized URL')
         return None
 
 
@@ -57,7 +57,7 @@ def url_language(url):
 ## Flavors
 
 
-class Flavors(object):
+class Flavors:
     @staticmethod
     def media_type(media):
         mtype = media.get('type')
@@ -73,7 +73,7 @@ class Flavors(object):
 
 
 @attr.s
-class Clip(object):
+class Clip:
     webpage = attr.ib()
     flavors = attr.ib()
     title = attr.ib(default='')
@@ -88,7 +88,7 @@ class Clip(object):
 
     def metadata(self, io):
         flavors_meta = sorted(
-            [self.flavor_meta(f) for f in self.flavors],
+            (self.flavor_meta(f) for f in self.flavors),
             key=lambda x: x.get('bitrate', 0))
         meta = [
             ('program_id', self.program_id),
@@ -186,7 +186,7 @@ class FailedClip(Clip):
 
 
 @attr.s
-class AreenaApiProgramInfo(object):
+class AreenaApiProgramInfo:
     media_id = attr.ib()
     title = attr.ib()
     description = attr.ib()
@@ -201,7 +201,7 @@ class AreenaApiProgramInfo(object):
     expired = attr.ib()
 
 
-class ClipExtractor(object):
+class ClipExtractor:
     def __init__(self, httpclient):
         self.httpclient = httpclient
 
@@ -322,7 +322,7 @@ class AreenaPlaylist(ClipExtractor):
         return len(body) != 0
 
 
-class AreenaPreviewApiParser(object):
+class AreenaPreviewApiParser:
     def __init__(self, data):
         self.preview = data or {}
 
@@ -429,7 +429,7 @@ class AreenaPreviewApiParser(object):
 
 class AreenaExtractor(AreenaPlaylist):
     def __init__(self, language_chooser, httpclient):
-        super(AreenaExtractor, self).__init__(httpclient)
+        super().__init__(httpclient)
         self.language_chooser = language_chooser
 
     def extract_clip(self, clip_url, title_formatter, ffprobe):

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -284,8 +284,7 @@ class AreenaPlaylist(ClipExtractor):
         while has_next_page:
             page = self.playlist_page(series_id, sort_order, page_size, offset)
             if page is None:
-                logger.warn('Playlist failed at offset {}. '
-                            'Some episodes may be missing!'.format(offset))
+                logger.warning(f'Playlist failed at offset {offset}. Some episodes may be missing!')
                 break
 
             playlist.extend(page)
@@ -295,9 +294,7 @@ class AreenaPlaylist(ClipExtractor):
         return playlist
 
     def playlist_page(self, series_id, sort_order, page_size, offset):
-        logger.debug('Getting a playlist page {series_id}, '
-                     'size = {size}, offset = {offset}'.format(
-                         series_id=series_id, size=page_size, offset=offset))
+        logger.debug(f'Getting a playlist page {series_id}, size = {page_size}, offset = {offset}')
 
         pl_url = self.playlist_url(series_id, sort_order, page_size, offset)
         playlist = jsonhelpers.load_json(pl_url, self.httpclient)
@@ -465,8 +462,10 @@ class AreenaExtractor(AreenaPlaylist):
         if program_info.pending:
             error_message = 'Stream not yet available.'
             if program_info.publish_timestamp:
-                error_message = ('{} Becomes available on {}'.format(
-                    error_message, program_info.publish_timestamp.isoformat()))
+                error_message = (
+                    f'{error_message} Becomes available on '
+                    f'{program_info.publish_timestamp.isoformat()}'
+                )
         elif program_info.expired:
             error_message = 'This stream has expired'
         elif all_streams and all(not s.is_valid() for s in all_streams):
@@ -691,9 +690,11 @@ class AreenaExtractor(AreenaPlaylist):
         )
 
     def program_info_url(self, program_id):
-        return 'https://areena.yle.fi/api/programs/v1/id/{}.json?' \
-            'app_id=areena_web_frontend_prod&' \
-            'app_key=4622a8f8505bb056c956832a70c105d4'.format(quote_plus(program_id))
+        return (
+            f'https://areena.yle.fi/api/programs/v1/id/{quote_plus(program_id)}.json'
+            '?app_id=areena_web_frontend_prod'
+            '&app_key=4622a8f8505bb056c956832a70c105d4'
+        )
 
     def preview_parser(self, pid, pageurl):
         preview_headers = {
@@ -715,10 +716,12 @@ class AreenaExtractor(AreenaPlaylist):
         return AreenaPreviewApiParser(preview_json)
 
     def preview_url(self, program_id):
-        return 'https://player.api.yle.fi/v1/preview/{}.json?' \
-            'language=fin&ssl=true&countryCode=FI&host=areenaylefi' \
-            '&app_id=player_static_prod' \
-            '&app_key=8930d72170e48303cf5f3867780d549b'.format(program_id)
+        return (
+            f'https://player.api.yle.fi/v1/preview/{program_id}.json?'
+            'language=fin&ssl=true&countryCode=FI&host=areenaylefi'
+            '&app_id=player_static_prod'
+            '&app_key=8930d72170e48303cf5f3867780d549b'
+        )
 
     def publish_event_is_current(self, event):
         return event.get('temporalStatus') == 'currently'

--- a/yledl/extractors.py
+++ b/yledl/extractors.py
@@ -61,7 +61,8 @@ class Flavors:
     @staticmethod
     def media_type(media):
         mtype = media.get('type')
-        if (mtype == 'AudioObject' or
+        if (
+            mtype == 'AudioObject' or
             (mtype is None and media.get('containerFormat') == 'mpeg audio')
         ):
             return 'audio'
@@ -309,13 +310,20 @@ class AreenaPlaylist(ClipExtractor):
 
     def playlist_url(self, series_id, sort_order, page_size=100, offset=0):
         offset_param = f'&offset={str(offset)}' if offset else ''
-        return (f'https://areena.yle.fi/api/programs/v1/episodes/{series_id}.json?'
-                f'type=program&availability=&'
-                f'limit={str(page_size)}&'
-                f'order=episode.hash%3A{sort_order}%2Cpublication.starttime%3A{sort_order}%2Ctitle.fi%3Aasc&'
-                f'app_id=areena_web_frontend_prod&'
-                f'app_key=4622a8f8505bb056c956832a70c105d4'
-                f'{offset_param}')
+        order_param = '%2C'.join((
+            f'episode.hash%3A{sort_order}',
+            f'publication.starttime%3A{sort_order}',
+            'title.fi%3Aasc'
+        ))
+        return (
+            f'https://areena.yle.fi/api/programs/v1/episodes/{series_id}.json?'
+            f'type=program&availability=&'
+            f'limit={str(page_size)}&'
+            f'order={order_param}&'
+            f'app_id=areena_web_frontend_prod&'
+            f'app_key=4622a8f8505bb056c956832a70c105d4'
+            f'{offset_param}'
+        )
 
     def is_playlist_page(self, html_tree):
         body = html_tree.xpath('/html/body[contains(@class, "series-cover-page")]')
@@ -843,10 +851,15 @@ class AreenaAudio2020Extractor(AreenaExtractor):
 
     def playlist_url(self, series_id, sort_order, page_size=100, offset=0):
         offset_param = f'&offset={str(offset)}' if offset else ''
+        order_param = '%2C'.join([
+            f'episode.hash%3A{sort_order}',
+            f'publication.starttime%3A{sort_order}',
+            'title.fi%3Aasc',
+        ])
         return (f'https://areena.yle.fi/api/programs/v1/episodes/{series_id}.json?'
                 f'type=program&availability=&'
                 f'limit={str(page_size)}&'
-                f'order=episode.hash%3A{sort_order}%2Cpublication.starttime%3A{sort_order}%2Ctitle.fi%3Aasc&'
+                f'order={order_param}&'
                 f'app_id=areena_web_radio_prod&'
                 f'app_key=b3a0dc973c0aab997f1021bc7a0e3157'
                 f'{offset_param}')
@@ -871,7 +884,7 @@ class ElavaArkistoExtractor(AreenaExtractor):
         return self.ordered_union(self._simple_dataids(tree), self._ydd_dataids(tree))
 
     def ordered_union(self, xs, ys):
-        union = list(xs) # copy
+        union = list(xs)  # copy
         for y in ys:
             if y not in union:
                 union.append(y)

--- a/yledl/ffprobe.py
+++ b/yledl/ffprobe.py
@@ -18,7 +18,7 @@ class Ffprobe:
         args = [
             self.ffprobe_binary,
             '-loglevel', ffmpeg_loglevel(logger.getEffectiveLevel()),
-            '-headers', 'X-Forwarded-For: %s\r\n' % self.x_forwarded_for,
+            '-headers', f'X-Forwarded-For: {self.x_forwarded_for}\r\n',
             '-show_programs',
             '-print_format', 'json=c=1',
             '-probesize', '80000000',

--- a/yledl/ffprobe.py
+++ b/yledl/ffprobe.py
@@ -8,7 +8,7 @@ from .utils import ffmpeg_loglevel
 logger = logging.getLogger('yledl')
 
 
-class Ffprobe(object):
+class Ffprobe:
     def __init__(self, ffprobe_binary, ffmpeg_binary, x_forwarded_for):
         self.ffprobe_binary = ffprobe_binary
         self.ffmpeg_binary = ffmpeg_binary
@@ -28,7 +28,7 @@ class Ffprobe(object):
             return json.loads(subprocess.check_output(args).decode('utf-8'))
         except subprocess.CalledProcessError as ex:
             raise ValueError(
-                'Stream probing failed with status {}'.format(ex.returncode))
+                f'Stream probing failed with status {ex.returncode}')
 
     def duration_seconds_file(self, filename):
         args = [self.ffmpeg_binary, '-stats', '-loglevel', 'fatal',
@@ -41,7 +41,7 @@ class Ffprobe(object):
                 .rsplit('\r', 1)[-1])
         except subprocess.CalledProcessError as ex:
             raise ValueError(
-                'Stream probing failed with status {}'.format(ex.returncode))
+                f'Stream probing failed with status {ex.returncode}')
         except UnicodeDecodeError:
             raise ValueError('Unexpected encoding on stream probing response')
 

--- a/yledl/ffprobe.py
+++ b/yledl/ffprobe.py
@@ -31,8 +31,14 @@ class Ffprobe:
                 f'Stream probing failed with status {ex.returncode}')
 
     def duration_seconds_file(self, filename):
-        args = [self.ffmpeg_binary, '-stats', '-loglevel', 'fatal',
-                '-i', 'file:' + filename, '-f', 'null', '-']
+        args = [
+            self.ffmpeg_binary,
+            '-stats',
+            '-loglevel', 'fatal',
+            '-i', f'file:{filename}',
+            '-f', 'null',
+            '-',
+        ]
 
         try:
             decoding_result = (

--- a/yledl/geolocation.py
+++ b/yledl/geolocation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 import logging
 import requests
@@ -8,7 +6,7 @@ import requests
 logger = logging.getLogger('yledl')
 
 
-class AreenaGeoLocation(object):
+class AreenaGeoLocation:
     def __init__(self, httpclient):
         self.httpclient = httpclient
 

--- a/yledl/http.py
+++ b/yledl/http.py
@@ -73,7 +73,7 @@ class HttpClient:
 
     def get(self, url, extra_headers=None):
         if url.find('://') == -1:
-            url = 'http://' + url
+            url = f'http://{url}'
         if '#' in url:
             url = url[:url.find('#')]
 
@@ -115,7 +115,8 @@ class HttpClient:
 
 
 def yledl_user_agent():
-    return 'yle-dl/' + version.split(' ')[0]
+    major = version.split(' ')[0]
+    return f'yle-dl/{major}'
 
 
 def html_meta_charset(html_bytes):

--- a/yledl/http.py
+++ b/yledl/http.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import lxml.html
 import lxml.etree
@@ -12,7 +10,7 @@ from .version import version
 logger = logging.getLogger('yledl')
 
 
-class HttpClient(object):
+class HttpClient:
     def __init__(self, io):
         self._session = self._create_session(io.proxy)
         self.x_forwarded_for = io.x_forwarded_for
@@ -50,23 +48,23 @@ class HttpClient(object):
         response = self.get(url, extra_headers)
         metacharset = html_meta_charset(response.content)
         if metacharset:
-            logger.debug('HTML meta charset: {}'.format(metacharset))
+            logger.debug(f'HTML meta charset: {metacharset}')
             response.encoding = metacharset
 
         try:
             page = response.text
             return lxml.html.fromstring(page)
         except lxml.etree.XMLSyntaxError as ex:
-            logger.warning('HTML syntax error: {}'.format(str(ex)))
+            logger.warning(f'HTML syntax error: {str(ex)}')
             return None
         except lxml.etree.ParserError as ex:
-            logger.warning('HTML parsing error: {}'.format(str(ex)))
+            logger.warning(f'HTML parsing error: {str(ex)}')
             return None
 
     def download_to_file(self, url, destination_filename):
         enc = sys.getfilesystemencoding()
         encoded_filename = destination_filename.encode(enc, 'replace')
-        logger.debug('HTTP GET {}'.format(url))
+        logger.debug(f'HTTP GET {url}')
         with open(encoded_filename, 'wb') as output:
             r = requests.get(url, headers=self.yledl_headers(), stream=True, timeout=20)
             r.raise_for_status()
@@ -83,12 +81,12 @@ class HttpClient(object):
         if extra_headers:
             headers.update(extra_headers)
 
-        logger.debug('HTTP GET {}'.format(url))
+        logger.debug(f'HTTP GET {url}')
         r = self._session.get(url, headers=headers)
-        logger.debug('HTTP status code: {}'.format(r.status_code))
+        logger.debug(f'HTTP status code: {r.status_code}')
         logger.debug('HTTP response headers:')
         for name, value in r.headers.items():
-            logger.debug('{}: {}'.format(name, value))
+            logger.debug(f'{name}: {value}')
         r.raise_for_status()
 
         return r
@@ -98,12 +96,12 @@ class HttpClient(object):
         if extra_headers:
             headers.update(extra_headers)
 
-        logger.debug('HTTP POST {}'.format(url))
+        logger.debug(f'HTTP POST {url}')
         r = self._session.post(url, json=json_data, headers=headers)
-        logger.debug('HTTP status code: {}'.format(r.status_code))
+        logger.debug(f'HTTP status code: {r.status_code}')
         logger.debug('HTTP response headers:')
         for name, value in r.headers.items():
-            logger.debug('{}: {}'.format(name, value))
+            logger.debug(f'{name}: {value}')
         r.raise_for_status()
 
         return r

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -107,8 +107,9 @@ class OutputFileNameGenerator:
         dir, _ = os.path.split(path)
         if not os.path.exists(dir):
             if not io.create_dirs:
-                logger.error('Directory "{}" does not exist. '
-                             'Use --create-dirs to automatically create.'.format(dir))
+                logger.error(
+                    f'Directory "{dir}" does not exist. Use --create-dirs to automatically create.'
+                )
                 return None
             logger.info(f'Creating directory "{dir}"')
             os.makedirs(dir)

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -130,8 +130,7 @@ class OutputFileNameGenerator:
         basename, old_ext = os.path.splitext(filename)
         if not old_ext or old_ext != ext:
             if old_ext:
-                logger.warn('Unsupported extension {}. Replacing it with {}'
-                            .format(old_ext, ext))
+                logger.warn(f'Unsupported extension {old_ext}. Replacing it with {ext}')
             return basename + ext
         else:
             return filename

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -33,7 +33,7 @@ def random_elisa_ipv4():
 
 
 @attr.s
-class DownloadLimits(object):
+class DownloadLimits:
     # Seek to this position (seconds) before starting the recording
     start_position = attr.ib(
         default=None,
@@ -47,7 +47,7 @@ class DownloadLimits(object):
 
 
 @attr.s
-class IOContext(object):
+class IOContext:
     outputfilename = attr.ib(default=None)
     preferred_format = attr.ib(default=None)
     destdir = attr.ib(default=None)
@@ -82,7 +82,7 @@ class IOContext(object):
                     return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
 
 
-class OutputFileNameGenerator(object):
+class OutputFileNameGenerator:
     def filename(self, title, extension, io):
         """Select a filename for the output."""
 
@@ -110,7 +110,7 @@ class OutputFileNameGenerator(object):
                 logger.error('Directory "{}" does not exist. '
                              'Use --create-dirs to automatically create.'.format(dir))
                 return None
-            logger.info('Creating directory "{}"'.format(dir))
+            logger.info(f'Creating directory "{dir}"')
             os.makedirs(dir)
 
         return path

--- a/yledl/jsonhelpers.py
+++ b/yledl/jsonhelpers.py
@@ -1,5 +1,6 @@
 import json
 
+
 def load_json(url, httpclient, headers=None):
     """Download and parse a JSON document at a given URL."""
     json_string = httpclient.download_page(url, headers)

--- a/yledl/kaltura.py
+++ b/yledl/kaltura.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import attr
 import logging
 import json
@@ -12,7 +10,7 @@ from .subtitles import EmbeddedSubtitle
 logger = logging.getLogger('yledl')
 
 
-class KalturaApiClient(object):
+class KalturaApiClient:
     def __init__(self, api_url, httpclient):
         self.api_url = api_url
         self.httpclient = httpclient
@@ -94,7 +92,7 @@ class YleKalturaApiClient(KalturaApiClient):
     http_origin = 'https://areena.yle.fi'
 
     def __init__(self, requests_session):
-        super(YleKalturaApiClient, self).__init__(self.api_url, requests_session)
+        super().__init__(self.api_url, requests_session)
 
     def playback_context(self, entry_id, referrer):
         subrequests = [
@@ -221,7 +219,7 @@ class YleKalturaApiClient(KalturaApiClient):
 
 
 @attr.s
-class DeliveryProfile(object):
+class DeliveryProfile:
     flavor_id = attr.ib()
     stream_format = attr.ib()
     manifest_file = attr.ib()

--- a/yledl/kaltura.py
+++ b/yledl/kaltura.py
@@ -126,7 +126,7 @@ class YleKalturaApiClient(KalturaApiClient):
                             if self.is_web_stream(fl)]
         num_non_web = len(flavor_assets) - len(filtered_flavors)
         if num_non_web:
-            logger.debug('Ignored %d non-web flavors' % num_non_web)
+            logger.debug(f'Ignored {num_non_web:d} non-web flavors')
 
         return self.create_flavors(filtered_flavors, delivery_profiles, referrer)
 
@@ -226,19 +226,13 @@ class DeliveryProfile:
 
     def manifest_url(self, entry_id, partner_id, client_tag, referrer):
         b64referrer = base64.b64encode(referrer.encode('utf-8')).decode('utf-8')
-        return ('https://cdnsecakmi.kaltura.com/p/{partner_id}/'
-                'sp/{partner_id}00/playManifest/entryId/{entry_id}/'
-                'flavorId/{flavor_id}/format/{stream_format}/protocol/https/'
-                '{manifest_file}?uiConfId=43362851&referrer={referrer}'
-                '&playSessionId=11111111-1111-1111-1111-111111111111'
-                '&clientTag={client_tag}'.format(
-                    partner_id=partner_id,
-                    entry_id=entry_id,
-                    flavor_id=self.flavor_id,
-                    stream_format=self.stream_format,
-                    manifest_file=self.manifest_file,
-                    referrer=b64referrer,
-                    client_tag=client_tag))
+        return (
+            f'https://cdnsecakmi.kaltura.com/p/{partner_id}/'
+            f'sp/{partner_id}00/playManifest/entryId/{entry_id}/'
+            f'flavorId/{self.flavor_id}/format/{self.stream_format}/protocol/https/'
+            f'{self.manifest_file}?uiConfId=43362851&referrer={b64referrer}'
+            f'&playSessionId=11111111-1111-1111-1111-111111111111&clientTag={client_tag}'
+        )
 
     def backends(self, entry_id, media_type, is_live, file_ext, partner_id, client_tag, referrer):
         backends = []

--- a/yledl/kaltura.py
+++ b/yledl/kaltura.py
@@ -74,7 +74,7 @@ class KalturaApiClient:
         return mrequest
 
     def perform_request(self, request, referrer, origin):
-        endpoint = self.api_url + '/api_v3/service/multirequest'
+        endpoint = f'{self.api_url}/api_v3/service/multirequest'
         extra_headers = {
             'Referer': referrer,
             'Origin': origin,
@@ -205,11 +205,11 @@ class YleKalturaApiClient(KalturaApiClient):
             manifest_file = url.split('/')[-1]
 
             for flavor_id in flavor_ids:
-                profile = DeliveryProfile(flavor_id, source_format,
-                                          manifest_file)
-
-                pkey = flavor_id + '_' + source_format
-                profiles_by_id_and_format[pkey] = profile
+                profiles_by_id_and_format[f'{flavor_id}_{source_format}'] = DeliveryProfile(
+                    flavor_id,
+                    source_format,
+                    manifest_file,
+                )
 
         profiles = {}
         for p in profiles_by_id_and_format.values():

--- a/yledl/localization.py
+++ b/yledl/localization.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
-
 default_languages = ['fin', 'swe']
 
 
-class TranslationChooser(object):
+class TranslationChooser:
     def __init__(self, preferred_three_letter_codes):
         if preferred_three_letter_codes:
             preferred = [x.lower() for x in preferred_three_letter_codes]

--- a/yledl/streamfilters.py
+++ b/yledl/streamfilters.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-
 import attr
 from .backends import Backends
 
 
 @attr.s
-class StreamFilters(object):
+class StreamFilters:
     """Parameters for deciding which of potentially multiple available stream
     versions to download.
     """

--- a/yledl/streamflavor.py
+++ b/yledl/streamflavor.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-
 import attr
 from .backends import FailingBackend
 
 
 @attr.s
-class StreamFlavor(object):
+class StreamFlavor:
     media_type = attr.ib()
     height = attr.ib(default=None, converter=attr.converters.optional(int))
     width = attr.ib(default=None, converter=attr.converters.optional(int))

--- a/yledl/streamprobe.py
+++ b/yledl/streamprobe.py
@@ -2,7 +2,6 @@ import logging
 from .backends import HLSBackend
 from .streamflavor import StreamFlavor, FailedFlavor
 
-
 logger = logging.getLogger('yledl')
 
 
@@ -38,7 +37,6 @@ class FullHDFlavorProber:
                                program_id=pid, is_live=is_live)
                 ]
             ))
-
 
         res = self._drop_duplicates(res)
         return sorted(res, key=lambda x: (x.height or 0, x.bitrate or 0))

--- a/yledl/streamprobe.py
+++ b/yledl/streamprobe.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 from .backends import HLSBackend
 from .streamflavor import StreamFlavor, FailedFlavor
@@ -8,12 +6,12 @@ from .streamflavor import StreamFlavor, FailedFlavor
 logger = logging.getLogger('yledl')
 
 
-class FullHDFlavorProber(object):
+class FullHDFlavorProber:
     def probe_flavors(self, manifest_url, is_live, ffprobe):
         try:
             programs = ffprobe.show_programs_for_url(manifest_url)
         except ValueError as ex:
-            return [FailedFlavor('Failed to probe stream: {}'.format(str(ex)))]
+            return [FailedFlavor(f'Failed to probe stream: {str(ex)}')]
 
         return self.programs_to_stream_flavors(programs, manifest_url, is_live)
 

--- a/yledl/subtitles.py
+++ b/yledl/subtitles.py
@@ -1,16 +1,14 @@
-# -*- coding: utf-8 -*-
-
 import attr
 
 
 @attr.s
-class Subtitle(object):
+class Subtitle:
     url = attr.ib()
     lang = attr.ib()
     category = attr.ib()
 
 
 @attr.s
-class EmbeddedSubtitle(object):
+class EmbeddedSubtitle:
     language = attr.ib()
     category = attr.ib()

--- a/yledl/timestamp.py
+++ b/yledl/timestamp.py
@@ -13,7 +13,7 @@ def parse_areena_timestamp(timestamp):
     timestamp = timestamp.strip()
     parsed = parse_areena_timestamp_py3(timestamp)
     if parsed is None:
-        logger.warning('Failed to parse timestamp: {}'.format(timestamp))
+        logger.warning(f'Failed to parse timestamp: {timestamp}')
 
     return parsed
 

--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -124,9 +124,9 @@ class TitleFormatter:
 
     def _episode_number(self, season, episode):
         if season and episode:
-            return 'S%02dE%02d' % (season, episode)
+            return f'S{season:02d}E{episode:02d}'
         elif episode:
-            return 'E%02d' % (episode)
+            return f'E{episode:02d}'
         else:
             return ''
 

--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -39,9 +39,11 @@ class TitleFormatter:
         return all(t.is_constant() for t in self.tokens)
 
     def maybe_missing_separators(self):
-        return (len(self.tokens) > 1 and
-                not any(isinstance(t, Literal) for t in self.tokens) and
-                not "_separator" in self.template)
+        return (
+            len(self.tokens) > 1 and
+            not any(isinstance(t, Literal) for t in self.tokens) and
+            "_separator" not in self.template
+        )
 
     def _parse_template(self, template):
         res = []

--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -82,7 +82,7 @@ class TitleFormatter:
         if series_title and series_title == ageless_title:
             episode_title = ''
         elif series_title:
-            series_prefix = re.escape(series_title) + r': *'
+            series_prefix = f'{re.escape(series_title)}: *'
             series_prefix_match = re.match(series_prefix, ageless_title, re.IGNORECASE)
             if series_prefix_match:
                 episode_title = ageless_title[series_prefix_match.end():]
@@ -90,7 +90,7 @@ class TitleFormatter:
         if subheading and not episode_title:
             return subheading
         elif subheading and subheading not in episode_title:
-            return episode_title + ': ' + subheading
+            return f'{episode_title}: {subheading}'
         else:
             return episode_title
 
@@ -118,7 +118,7 @@ class TitleFormatter:
 
     def _series_separator(self, series_title):
         if series_title:
-            return series_title + ': '
+            return f'{series_title}: '
         else:
             return ''
 
@@ -133,7 +133,7 @@ class TitleFormatter:
     def _episode_number_separator(self, season, episode):
         value = self._episode_number(season, episode)
         if value:
-            return value + '-'
+            return f'{value}-'
         else:
             return ''
 

--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
 import re
 from datetime import datetime
 
 
-class TitleFormatter(object):
+class TitleFormatter:
     def __init__(self, template='${series_separator}${title}: ${episode_separator}${timestamp}'):
         self.template = template
         self.tokens = self._parse_template(template)
@@ -152,7 +150,7 @@ class TitleFormatter(object):
             return ''
 
 
-class Substitution(object):
+class Substitution:
     def __init__(self, variable_name):
         self.variable_name = variable_name
 
@@ -165,7 +163,7 @@ class Substitution(object):
         return val.replace('/', '_') if val else ''
 
 
-class Literal(object):
+class Literal:
     def __init__(self, text):
         self.text = text
 

--- a/yledl/utils.py
+++ b/yledl/utils.py
@@ -24,7 +24,7 @@ def print_enc(msg, out=None, linefeed_and_flush=True):
 
 
 def sane_filename(name, excludechars):
-    tr = dict((ord(c), ord('_')) for c in excludechars)
+    tr = {ord(c): ord('_') for c in excludechars}
     x = re.sub(r'\s+', ' ', name, flags=re.UNICODE).strip(' .').translate(tr)
     return x or 'ylevideo'
 

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -263,7 +263,7 @@ def execute_action(url, action, io, httpclient, title_formatter, stream_filters)
     extractor = extractor_factory(
         url, stream_filters, language_chooser(url, io), httpclient)
     if not extractor:
-        logger.error('Unsupported URL %s.' % url)
+        logger.error(f'Unsupported URL {url}.')
         logger.error('If you think yle-dl should support this page, open a '
                      'bug report at https://github.com/aajanki/yle-dl/issues')
         return RD_FAILED
@@ -334,7 +334,7 @@ def bitrate_from_arg(arg):
         try:
             return int(arg)
         except ValueError:
-            logger.warning('Invalid bitrate %s, defaulting to best' % arg)
+            logger.warning(f'Invalid bitrate {arg}, defaulting to best')
             return 999999
 
 
@@ -467,8 +467,7 @@ def main(argv=sys.argv):
     for i, url in enumerate(urls):
         if len(urls) > 1:
             logger.info('')
-            logger.info('Now downloading from URL {}/{}: {}'.format(
-                i + 1, len(urls), url))
+            logger.info(f'Now downloading from URL {i + 1}/{len(urls)}: {url}')
 
         io.download_limits.start_position = \
             args.startposition or start_position_from_url(url)

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -51,7 +51,7 @@ def yledl_logger():
             if record.levelno == logging.INFO:
                 return record.getMessage()
             else:
-                return super(PlainInfoFormatter, self).format(record)
+                return super().format(record)
 
     logger = logging.getLogger('yledl')
     handler = logging.StreamHandler()
@@ -64,7 +64,7 @@ def yledl_logger():
 logger = yledl_logger()
 
 
-class StreamAction(object):
+class StreamAction:
     DOWNLOAD = 1
     PIPE = 2
     PRINT_STREAM_URL = 3
@@ -348,7 +348,7 @@ def resolution_from_arg(arg):
     try:
         return int(arg)
     except ValueError:
-        logger.warning('Invalid resolution: {}'.format(arg))
+        logger.warning(f'Invalid resolution: {arg}')
         return None
 
 

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -81,10 +81,10 @@ def arg_parser():
                     file = sys.stderr
                 print_enc(message, file, False)
 
-    description = \
-        ('yle-dl %s: Download media files from Yle Areena and Elävä Arkisto\n'
-         'Copyright (C) 2009-2022 Antti Ajanki <antti.ajanki@iki.fi>, '
-         'license: GPLv3\n' % version)
+    description = (
+        f'yle-dl {version}: Download media files from Yle Areena and Elävä Arkisto\n'
+        'Copyright (C) 2009-2022 Antti Ajanki <antti.ajanki@iki.fi>, license: GPLv3\n'
+    )
 
     parser = ArgumentParserEncoded(
         default_config_files=['~/.yledl.conf'],
@@ -389,11 +389,14 @@ def warn_on_obsolete_ffmpeg(backends, io):
     if 'ffmpeg' in backends:
         ffmpeg_version = io.ffmpeg_version()
         if ffmpeg_version is not None:
-            logger.debug('Detected ffmpeg {}.{}.{}'.format(*ffmpeg_version))
+            formatted_ffmpeg_version = '{}.{}.{}'.format(*ffmpeg_version)
+            logger.debug(f'Detected ffmpeg {formatted_ffmpeg_version}')
             if ffmpeg_version < (4, 1, 0):
-                logger.warning('Your version of ffmpeg ({}.{}.{}) might not download '
-                               'all streams correctly.'.format(*ffmpeg_version))
-                logger.warning('Please upgrade ffmpeg to version 4.1.0 or later.')
+                logger.warning(
+                    f'Your version of ffmpeg ({formatted_ffmpeg_version}) '
+                    'might not download all streams correctly.\n'
+                    'Please upgrade ffmpeg to version 4.1.0 or later.'
+                )
 
 
 def warn_on_output_template_syntax_change(title_formatter):


### PR DESCRIPTION
Since yle-dl is Python 3.6+ only, we can modernize a thing or two:

This PR:

* runs `pyupgrade --py36-plus` to get rid of some vestigial py2-isms
* fixes a bunch of things pycodestyle was complaining about (by hand)
* runs `flynt` to auto-convert string formatting to f-strings
* finally, applies some manual elbow grease to fix up usages of `.format`, ` % `, ` + `, etc. to f-strings as well