### PR TITLE
Add yledl/__main__.py to allow python -m yledl

### DIFF
--- a/yledl/__main__.py
+++ b/yledl/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from .yledl import main
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This allows running with

```
python -m yledl
```
instead of
```
python -m yledl.yledl
```
(which also causes a spurious `RuntimeWarning: 'yledl.yledl' found in sys.modules after import of package 'yledl', but prior to execution of 'yledl.yledl'; this may result in unpredictable behaviour`).

