### PR TITLE
Fix postprocess and handling of filename with no directory component

### DIFF
--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -221,8 +221,8 @@ class YleDlDownloader:
                 s.name for s in fl.streams if s.is_valid())
 
         error_messages = [s.error_message
-                          for s in fl.streams if not s.is_valid()
-                          for fl in flavors]
+                          for fl in flavors
+                          for s in fl.streams if not s.is_valid()]
 
         if supported_backends:
             msg = (f'Required backend not enabled. Try: --backend {",".join(supported_backends)}')

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -275,4 +275,4 @@ class YleDlDownloader:
         if postprocess_command:
             args = [postprocess_command, videofile]
             args.extend(subtitlefiles)
-            return Subprocess().execute(args, None)
+            return Subprocess().execute([args], None)

--- a/yledl/downloader.py
+++ b/yledl/downloader.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-import os.path
+import os
 from .utils import sane_filename
 from .backends import Subprocess
 from .exitcodes import to_external_rd_code, RD_SUCCESS, RD_INCOMPLETE, \

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -1,7 +1,7 @@
 import attr
 import ipaddress
 import logging
-import os.path
+import os
 import random
 import re
 import subprocess

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -112,7 +112,7 @@ class OutputFileNameGenerator:
             path = self._impose_maximum_filename_length(path)
 
         dir, _ = os.path.split(path)
-        if not os.path.exists(dir):
+        if dir and not os.path.exists(dir):
             if not io.create_dirs:
                 logger.error(
                     f'Directory "{dir}" does not exist. Use --create-dirs to automatically create.'

--- a/yledl/titleformatter.py
+++ b/yledl/titleformatter.py
@@ -33,7 +33,7 @@ class TitleFormatter:
             'program_id': program_id,
         }
 
-        return self._substitute(self.tokens, values)
+        return self._substitute(values)
 
     def is_constant_pattern(self):
         return all(t.is_constant() for t in self.tokens)
@@ -66,7 +66,7 @@ class TitleFormatter:
 
         return res
 
-    def _substitute(self, tokens, values):
+    def _substitute(self, values):
         res = []
         for token in self.tokens:
             subst = token.substitute(values)


### PR DESCRIPTION
I noticed a couple bugs the other day when I tried to use the `--postprocess` option.

Downloading the news with the following command (using `echo` as a placeholder postprocessing command)
```
yle-dl 'https://areena.yle.fi/1-50922783' -o uutiset --postprocess echo
```

I got the following error:
```
...
Stream saved to uutiset.mkv
ERROR: Failed to execute e c h o | u u t i s e t . m k v
ERROR: No such file or directory
```

The user provided command with the yle-dl provided arguments were passed to `Subprocess().execute()` with one level too shallow nesting. Thus the strings were treated each as a single piece of a pipeline.

---

I didn't have the latest version locally (some pre `--create-dirs` version), so once I had fixed the above, I got the following error:

```
yle-dl 20220213: Download media files from Yle Areena and Elävä Arkisto
Copyright (C) 2009-2022 Antti Ajanki <antti.ajanki@iki.fi>, license: GPLv3

ERROR: Directory "" does not exist. Use --create-dirs to automatically create.
ERROR: Directory "" does not exist. Use --create-dirs to automatically create.
```

I don't know why the error is shown twice, but I added a check for the cases with no directory component.

---

I also included few other fixes and minor code quality improvements.