### PR TITLE
mpv's --cache flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ yle-dl https://areena.yle.fi/1-787136 -o video.mkv
 Playing in mpv (or in vlc or in any other video player) without downloading first:
 
 ```
-yle-dl --pipe https://areena.yle.fi/1-787136 | mpv --cache=1000 --slang=fi -
+yle-dl --pipe https://areena.yle.fi/1-787136 | mpv --cache-secs=1000 --slang=fi -
 ```
 
 Executing a script to postprocess a downloaded video (see the example postprocessing script at scripts/muxmp4):


### PR DESCRIPTION
https://mpv.io/manual/stable/#cache

The flag `--cache=1000` doesn't exist — `--cache-secs=1000` can be used  (assuming seconds).

```
Invalid value for option cache: 1000
Valid values are:
    no
    auto
    yes
Error parsing option cache (option parameter could not be parsed)
Setting commandline option --cache=1000 failed.
```
