### PR TITLE
Clarify license by mentioning "or later" everywhere

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 yle-dl - download videos from Yle servers
 Copyright 2009-2022 Antti Ajanki
-Distributed under the GPL v3
+Distributed under the GPL v3 or later
 
 <unreleased>
 

--- a/README.fi
+++ b/README.fi
@@ -1,6 +1,6 @@
 Apuohjelma videoiden lataamiseen Yle Areenasta
 Copyright (C) 2010-2022 Antti Ajanki, antti.ajanki@iki.fi
-Ohjelmistolisenssi: GPLv3
+Ohjelmistolisenssi: GPL v3 tai myöhempi
 Kotisivu: https://aajanki.github.io/yle-dl/
 Lähdekoodi: https://github.com/aajanki/yle-dl
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Download videos from Yle servers
 
 Copyright (C) 2010-2022 Antti Ajanki, antti.ajanki@iki.fi
 
-License: GPLv3
+License: GPL v3 or later
 
 Homepage: https://aajanki.github.io/yle-dl/index-en.html
 


### PR DESCRIPTION
Most places where GPL v3 is mentioned
also already mention that any later version is also accepted.
There were just a couple of top level files where this was not explicit.
Added to avoid any unclarity about the license.

The background for this pull request is that I am attempting to package yle-dl for Fedora.
Fedora requires a license review to be conducted,
and initially README's plain "GPLv3" led me to believe the correct license if "GPL v3 only" —
but the rest of repository content indicate it is actually "or later".