### PR TITLE
Search for the config file under XDG_CONFIG_HOME

### DIFF
--- a/README.fi.md
+++ b/README.fi.md
@@ -120,10 +120,10 @@ yle-dl --ffmpeg avconv --ffprobe avprobe ...
 Asetustiedosto
 --------------
 
-Kahdella viivalla (--) alkavien valitsimien arvot voi asettaa myös
-asetustiedostossa. Asetukset luetaan tiedostosta ~/.yledl.conf tai
-tiedostosta, jonka nimi annetaan --config-valitsimella. Lähdekoodien
-mukana tulee esimerkkitiedosto yledl.conf.sample.
+Kahdella viivalla (--) alkavien valitsimien arvot voi asettaa myös asetustiedostossa.
+Asetukset luetaan tiedostosta `~/.yledl.conf` (tai vaihtoehtoisesti `~/.config/yledl.conf`)
+tai tiedostosta, jonka nimi annetaan `--config`-valitsimella. Lähdekoodien mukana tulee
+esimerkkitiedosto `yledl.conf.sample`.
 
 Asetustiedoston syntaksi: avain=arvo, avain=true.
 Komentorivivalitsimet ohittavat asetustiedostossa annetut arvot, jos

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ yle-dl --ffmpeg avconv --ffprobe avprobe ...
 Config file
 -----------
 
-Arguments that start with '--' can also be set in a config file. The
-default config file is `~/.yledl.conf` or one can be specified via
-`--config`. See [yledl.conf.sample](yledl.conf.sample) for an example
-configuration.
+Arguments that start with '--' can also be set in a config file. The default
+config file is `~/.yledl.conf` (or alternatively `~/.config/yledl.conf`) or
+one can be specified via `--config`. See [yledl.conf.sample](yledl.conf.sample)
+for an example configuration.
 
 Config file syntax allows: key=value, flag=true. If an arg is
 specified in more than one place, then command line values override

--- a/yledl.conf.sample
+++ b/yledl.conf.sample
@@ -1,6 +1,6 @@
 # Sample configuration file for yle-dl.
 #
-# Edit and copy this file to ~/.yledl.conf
+# Edit and copy this file to either ~/.yledl.conf or ~/.config/yledl.conf
 #
 # See 'yle-dl --help' for all arguments that can be configured here.
 

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -88,8 +88,9 @@ def arg_parser():
         'Copyright (C) 2009-2023 Antti Ajanki <antti.ajanki@iki.fi>, license: GPLv3\n'
     )
 
+    xdg_config_home = os.getenv('XDG_CONFIG_HOME') or '~/.config'
     parser = ArgumentParserEncoded(
-        default_config_files=['~/.yledl.conf'],
+        default_config_files=['~/.yledl.conf', f'{xdg_config_home}/yledl.conf'],
         description=description,
         formatter_class=configargparse.RawDescriptionHelpFormatter)
     parser.add_argument('-V', '--verbose',


### PR DESCRIPTION
According to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), config files should be under the `$XDG_CONFIG_HOME` directory (which defaults to `~/.config`), and not directly under the home directory.

In other words, a lot of modern Linux apps have their config under `~/.config` and not directly in the home dir, which makes your home a bit neater.

There was already a list of default config paths, so this was nice and easy to add.