### PR TITLE
Improve FFmpeg version checker regular expression to fix subtitle downloads

### DIFF
--- a/yledl/io.py
+++ b/yledl/io.py
@@ -105,7 +105,7 @@ class IOContext:
                 )
                 if p.returncode == 0:
                     first_line = p.stdout.splitlines()[0]
-                    m = re.match(r'ffmpeg version (\d+)\.(\d+)', first_line)
+                    m = re.match(r'ffmpeg version n?(\d+)\.(\d+)', first_line)
                     if m:
                         ver = int(m.group(1)), int(m.group(2))
             except FileNotFoundError:


### PR DESCRIPTION
# TL;DR
- some Linux distributions package `ffmpeg` such that `ffmpeg`'s version number is prefixed with letter `n`
- this extra prefix `n` confuses `yle-dl`'s `ffmpeg_version` checker function and consequently subtitles fail to download (see #380)
- this PR takes the extra prefix `n` into account in the regular expression in `ffmpeg_version`

# Background

Arch Linux builds `ffmpeg` directly from [Git sources](https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg/-/blob/1e27244932c2c61ab340b357ff4ac8dd0065e3af/PKGBUILD#L123). This means that it uses [Git tags](https://git.ffmpeg.org/gitweb/ffmpeg.git/tags) as version numbers for the binary. In other words, version numbers will have `n` prefix.

For example:
```
arch$ ffmpeg -loglevel quiet -version
ffmpeg version n7.1.1 Copyright (c) 2000-2025 the FFmpeg developers
built with gcc 15.1.1 (GCC) 20250425
```

The `n` prefix breaks the regular expression in `ffmpeg_version` checker function in [`io.py`](https://github.com/aajanki/yle-dl/blob/dce1110fcb7a1304fd3843f8ac3a613d95a181d9/yledl/io.py#L108)

When `ffmpeg` is built from release tar balls, there is no `n` prefix and `yle-dl` works without issues. For example, Debian, Ubuntu and Alpine build `ffmpeg` from these releases. As a concrete example see Alpine's `ffmpeg` [`APKBUILD`](https://gitlab.alpinelinux.org/alpine/aports/-/blob/96d03ae8ccd0a75e113ddde5626781a11772a127/community/ffmpeg/APKBUILD#L75).

```
alpine$ ffmpeg -loglevel quiet -version
ffmpeg version 6.1.2 Copyright (c) 2000-2024 the FFmpeg developers
built with gcc 14.2.0 (Alpine 14.2.0)
```

Tested in:
- Alpine 3.21
- Arch
- Debian 12
