### PR TITLE
Fix: stream-copy audio in pipe mode instead of re-encoding

### DIFF
--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -448,7 +448,7 @@ class DASHHLSBackend(ExternalDownloader):
             self._duration_arg(io.download_limits)
             + self._map_video_and_audio_streams(io)
             + self._subtitle_args(io)
-            + ['-vcodec', 'copy', '-acodec', 'aac', '-dn', '-f', 'matroska', 'pipe:1']
+            + ['-vcodec', 'copy', '-acodec', 'copy', '-dn', '-f', 'matroska', 'pipe:1']
         )
 
     def output_args_file(self, clip, io, output_name):


### PR DESCRIPTION
## Summary

- Change `-acodec aac` to `-acodec copy` in `output_args_pipe()` (`backends.py` line 451)
- `output_args_file()` (line 460-470) already uses `-acodec copy`; pipe mode should match
- All Yle Areena content uses AAC-LC audio, so transcoding AAC→AAC is pure waste (CPU cost, slight quality loss from re-encoding)
- Stream-copy is lossless, faster, and matches the file download behavior

If some content uses a codec incompatible with Matroska over pipe, happy to parametrize the codec choice — but re-encoding AAC to AAC should not be the default.

## Test plan

- [ ] `ruff check yledl/backends.py` passes
- [ ] `ruff format --check yledl/backends.py` passes
- [ ] Unit tests pass
- [ ] Manual test: `yle-dl --pipe <URL> | ffprobe -` confirms audio is AAC-LC (stream-copied, not re-encoded)