### PR TITLE
Add --subdelay option to shift subtitle timing

### DIFF
--- a/README.fi.md
+++ b/README.fi.md
@@ -61,6 +61,7 @@ Valitsimet:
 * `--showmetadata`  Tulostaa metatietoja ohjelmasta. Katso docs/metadata.md
 * `--restrict-filename-no-specials`  Tuota Windows-yhteensopivia tiedoston nimiä
 * `--sublang lan`   Jätä tekstitykset lataamatta, jos lang on "none"
+* `--subdelay ms`   Siirrä tekstityksen ajoitusta ms millisekuntia (positiivinen = myöhemmäksi, negatiivinen = aiemmaksi)
 * `--resolution r`  Rajoita ladattavan striimin pystyresoluutiota
 * `--maxbitrate br` Rajoita ladattavan striimin bittinopeutta (kB/s)
 * `--postprocess c` Suorita ohjelma c onnistuneen latauksen jälkeen. Ohjelmalle c annetaan parametriksi ladatun videotiedoston nimi ja mahdollisten tekstitystiedostojen nimet.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ yle-dl options:
 
 * `--sublang lang`    Disable subtitles if lang is "none"
 
+* `--subdelay ms`     Shift subtitle timing by ms milliseconds (positive = later, negative = earlier)
+
 * `--resolution res`  Maximum vertical resolution in pixels
 
 * `--maxbitrate br`   Maximum bitrate stream to download, integer in kB/s or "best" or "worst". Not all streams support limited bitrates.

--- a/README.sv.md
+++ b/README.sv.md
@@ -55,6 +55,7 @@ yle-dl alternativ:
 * `--destdir dir`     Spara filer till en mapp
 * `--latestepisode`   Ladda ner senaste avsnitten
 * `--showmetadata`    Skriv ut streamens metadata [i JSON format](docs/metadata.md)
+* `--subdelay ms`     Förskjut undertexternas timing med ms millisekunder (positivt = senare, negativt = tidigare)
 
 Använd kommandot `yle-dl --help` för att se alla alternativ.
 

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -21,6 +21,7 @@ import logging
 import os
 import os.path
 import platform
+import re
 import signal
 import shlex
 import subprocess
@@ -480,6 +481,37 @@ class DASHHLSBackend(ExternalDownloader):
             ]
         )
 
+    def save_stream(self, output_name, clip, io):
+        res = super().save_stream(output_name, clip, io)
+        if res == RD_SUCCESS and io.subtitle_delay_ms and output_name != '-':
+            self._apply_subtitle_delay_to_file(output_name, io)
+        return res
+
+    def _apply_subtitle_delay_to_file(self, filename, io):
+        delay_s = io.subtitle_delay_ms / 1000.0
+        sub_spec = f'1:s{":?" if io.ffmpeg_version() >= (7, 1) else "?"}'
+        base, ext = os.path.splitext(filename)
+        tmp = base + '.tmp_subdelay' + ext
+        args = [
+            io.ffmpeg_binary,
+            '-y',
+            '-loglevel', ffmpeg_loglevel(logger.getEffectiveLevel()),
+            '-i', f'file:{filename}',
+            '-itsoffset', str(delay_s),
+            '-i', f'file:{filename}',
+            '-map', '0:v', '-map', '0:a', '-map', sub_spec,
+            '-c', 'copy',
+            f'file:{tmp}',
+        ]
+        logger.debug(f'Applying subtitle delay: {shlex.join(args)}')
+        ret = subprocess.run(args).returncode
+        if ret == 0:
+            os.replace(tmp, filename)
+        else:
+            logger.warning('Failed to apply subtitle delay')
+            if os.path.exists(tmp):
+                os.remove(tmp)
+
     def stream_url(self):
         return self.url
 
@@ -505,6 +537,9 @@ class HLSAudioBackend(DASHHLSBackend):
 
     def file_extension(self, preferred):
         return MandatoryFileExtension('.mp3')
+
+    def save_stream(self, output_name, clip, io):
+        return ExternalDownloader.save_stream(self, output_name, clip, io)
 
     def output_args_file(self, clip, io, output_name):
         return (
@@ -571,6 +606,30 @@ class WgetBackend(ExternalDownloader):
             basename = os.path.splitext(video_file_name)[0]
             destination_file = f'{basename}.srt'
             HttpClient(io).download_to_file(sub.url, destination_file)
+            if io.subtitle_delay_ms:
+                self._shift_srt_timestamps(destination_file, io.subtitle_delay_ms)
+
+    def _shift_srt_timestamps(self, filename, delay_ms):
+        time_re = re.compile(
+            r'(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})'
+        )
+
+        def ms_to_srt(ms):
+            ms = max(0, ms)
+            h, ms = divmod(ms, 3_600_000)
+            m, ms = divmod(ms, 60_000)
+            s, ms = divmod(ms, 1000)
+            return f'{h:02d}:{m:02d}:{s:02d},{ms:03d}'
+
+        def shift(match):
+            start = (int(match.group(1)) * 3600 + int(match.group(2)) * 60 + int(match.group(3))) * 1000 + int(match.group(4))
+            end = (int(match.group(5)) * 3600 + int(match.group(6)) * 60 + int(match.group(7))) * 1000 + int(match.group(8))
+            return f'{ms_to_srt(start + delay_ms)} --> {ms_to_srt(end + delay_ms)}'
+
+        with open(filename, encoding='utf-8') as f:
+            content = f.read()
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(time_re.sub(shift, content))
 
     def build_args(self, output_name, clip, io):
         args = self.shared_wget_args(io, output_name)

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -72,6 +72,7 @@ class IOContext:
     wget_binary: str = 'wget'
     create_dirs: bool = False
     xattr: bool = False
+    subtitle_delay_ms: Optional[int] = None
     __cached_ffmpeg_version: Optional[tuple[int, int]] = None
 
     def ffprobe(self):

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -206,6 +206,12 @@ def _add_quality_arguments(parser):
         help='Preferred video output format: mkv (default) or mp4. Applies only when '
         'downloading with ffmpeg',
     )
+    qual_group.add_argument(
+        '--subdelay',
+        metavar='MS',
+        type=int,
+        help='Shift subtitle timing by MS milliseconds (positive = later, negative = earlier)',
+    )
 
 
 def _add_resume_arguments(io_group):
@@ -641,6 +647,7 @@ def main(argv=sys.argv):
         wget_binary=args.wget or 'wget',
         create_dirs=args.create_dirs,
         xattr=args.xattrs,
+        subtitle_delay_ms=args.subdelay,
     )
 
     action = _parse_action(args)


### PR DESCRIPTION
This is related to:  https://github.com/aajanki/yle-dl/issues/360

- New --subdelay MS argument shifts subtitle timing by the given number of milliseconds (positive = later, negative = earlier)