### PR TITLE
Add --subtitles-only option to skip video/audio download

### DIFF
--- a/README.fi.md
+++ b/README.fi.md
@@ -62,6 +62,7 @@ Valitsimet:
 * `--restrict-filename-no-specials`  Tuota Windows-yhteensopivia tiedoston nimiä
 * `--sublang lan`   Jätä tekstitykset lataamatta, jos lang on "none"
 * `--subdelay ms`   Siirrä tekstityksen ajoitusta ms millisekuntia (positiivinen = myöhemmäksi, negatiivinen = aiemmaksi)
+* `--subtitles-only`  Lataa vain tekstitystiedosto, ohita video ja ääni
 * `--resolution r`  Rajoita ladattavan striimin pystyresoluutiota
 * `--maxbitrate br` Rajoita ladattavan striimin bittinopeutta (kB/s)
 * `--postprocess c` Suorita ohjelma c onnistuneen latauksen jälkeen. Ohjelmalle c annetaan parametriksi ladatun videotiedoston nimi ja mahdollisten tekstitystiedostojen nimet.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ yle-dl options:
 
 * `--subdelay ms`     Shift subtitle timing by ms milliseconds (positive = later, negative = earlier)
 
+* `--subtitles-only`  Download only subtitle file, skip video and audio
+
 * `--resolution res`  Maximum vertical resolution in pixels
 
 * `--maxbitrate br`   Maximum bitrate stream to download, integer in kB/s or "best" or "worst". Not all streams support limited bitrates.

--- a/README.sv.md
+++ b/README.sv.md
@@ -57,6 +57,8 @@ yle-dl alternativ:
 * `--showmetadata`    Skriv ut streamens metadata [i JSON format](docs/metadata.md)
 * `--subdelay ms`     Förskjut undertexternas timing med ms millisekunder (positivt = senare, negativt = tidigare)
 
+* `--subtitles-only`  Ladda bara ned undertextfile, hoppa över video och ljud
+
 Använd kommandot `yle-dl --help` för att se alla alternativ.
 
 ## Konfigurationfil

--- a/yledl/backends.py
+++ b/yledl/backends.py
@@ -136,6 +136,36 @@ class BaseDownloader:
 
 
 class ExternalDownloader(BaseDownloader):
+    def _shift_srt_timestamps(self, filename, delay_ms):
+        time_re = re.compile(
+            r'(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})'
+        )
+
+        def ms_to_srt(ms):
+            ms = max(0, ms)
+            h, ms = divmod(ms, 3_600_000)
+            m, ms = divmod(ms, 60_000)
+            s, ms = divmod(ms, 1000)
+            return f'{h:02d}:{m:02d}:{s:02d},{ms:03d}'
+
+        def shift(match):
+            start = (
+                int(match.group(1)) * 3600
+                + int(match.group(2)) * 60
+                + int(match.group(3))
+            ) * 1000 + int(match.group(4))
+            end = (
+                int(match.group(5)) * 3600
+                + int(match.group(6)) * 60
+                + int(match.group(7))
+            ) * 1000 + int(match.group(8))
+            return f'{ms_to_srt(start + delay_ms)} --> {ms_to_srt(end + delay_ms)}'
+
+        with open(filename, encoding='utf-8') as f:
+            content = f.read()
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(time_re.sub(shift, content))
+
     def save_stream(self, output_name, clip, io):
         self.warn_on_unsupported_resume(output_name, clip, io)
 
@@ -464,6 +494,15 @@ class DASHHLSBackend(ExternalDownloader):
         )
 
     def output_args_file(self, clip, io, output_name):
+        if io.subtitles_only:
+            short_code = two_letter_language_code(io.subtitles) or io.subtitles
+            return (
+                self._duration_arg(io.download_limits)
+                + ['-scodec', 'srt',
+                   '-map', self._optional_stream(f'0:s:m:language:{short_code}', io),
+                   '-map', self._optional_stream(f'0:s:m:language:{io.subtitles}', io)]
+                + ['-vn', '-an', f'file:{output_name}']
+            )
         return (
             self._duration_arg(io.download_limits)
             + self._metadata_args(clip, io)
@@ -484,7 +523,10 @@ class DASHHLSBackend(ExternalDownloader):
     def save_stream(self, output_name, clip, io):
         res = super().save_stream(output_name, clip, io)
         if res == RD_SUCCESS and io.subtitle_delay_ms and output_name != '-':
-            self._apply_subtitle_delay_to_file(output_name, io)
+            if io.subtitles_only:
+                self._shift_srt_timestamps(output_name, io.subtitle_delay_ms)
+            else:
+                self._apply_subtitle_delay_to_file(output_name, io)
         return res
 
     def _apply_subtitle_delay_to_file(self, filename, io):
@@ -535,6 +577,8 @@ class DASHHLSBackend(ExternalDownloader):
         return f'{stream_spec}{sep}?'
 
     def full_stream_already_downloaded(self, filename, clip, io):
+        if io.subtitles_only:
+            return False
         ffprobe = io.ffprobe()
         return ffprobe and ffprobe.full_stream_already_downloaded(
             filename, clip.duration_seconds
@@ -597,6 +641,9 @@ class WgetBackend(ExternalDownloader):
         if clip is not None:
             self.download_external_subtitles(clip.subtitles, output_name, io)
 
+        if io.subtitles_only:
+            return RD_SUCCESS
+
         res = super().save_stream(output_name, clip, io)
         if res != 0 and logger.getEffectiveLevel() >= logging.ERROR:
             logger.error('wget failed! Increase verbosity to see more details.')
@@ -618,36 +665,6 @@ class WgetBackend(ExternalDownloader):
             HttpClient(io).download_to_file(sub.url, destination_file)
             if io.subtitle_delay_ms:
                 self._shift_srt_timestamps(destination_file, io.subtitle_delay_ms)
-
-    def _shift_srt_timestamps(self, filename, delay_ms):
-        time_re = re.compile(
-            r'(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})'
-        )
-
-        def ms_to_srt(ms):
-            ms = max(0, ms)
-            h, ms = divmod(ms, 3_600_000)
-            m, ms = divmod(ms, 60_000)
-            s, ms = divmod(ms, 1000)
-            return f'{h:02d}:{m:02d}:{s:02d},{ms:03d}'
-
-        def shift(match):
-            start = (
-                int(match.group(1)) * 3600
-                + int(match.group(2)) * 60
-                + int(match.group(3))
-            ) * 1000 + int(match.group(4))
-            end = (
-                int(match.group(5)) * 3600
-                + int(match.group(6)) * 60
-                + int(match.group(7))
-            ) * 1000 + int(match.group(8))
-            return f'{ms_to_srt(start + delay_ms)} --> {ms_to_srt(end + delay_ms)}'
-
-        with open(filename, encoding='utf-8') as f:
-            content = f.read()
-        with open(filename, 'w', encoding='utf-8') as f:
-            f.write(time_re.sub(shift, content))
 
     def build_args(self, output_name, clip, io):
         args = self.shared_wget_args(io, output_name)

--- a/yledl/io.py
+++ b/yledl/io.py
@@ -73,6 +73,7 @@ class IOContext:
     create_dirs: bool = False
     xattr: bool = False
     subtitle_delay_ms: Optional[int] = None
+    subtitles_only: bool = False
     __cached_ffmpeg_version: Optional[tuple[int, int]] = None
 
     def ffprobe(self):

--- a/yledl/yledl.py
+++ b/yledl/yledl.py
@@ -212,6 +212,12 @@ def _add_quality_arguments(parser):
         type=int,
         help='Shift subtitle timing by MS milliseconds (positive = later, negative = earlier)',
     )
+    qual_group.add_argument(
+        '--subtitles-only',
+        action='store_true',
+        default=False,
+        help='Download only subtitle files, skip video and audio',
+    )
 
 
 def _add_resume_arguments(io_group):
@@ -625,6 +631,11 @@ def main(argv=sys.argv):
     dl_limits = DownloadLimits(args.startposition, args.duration, args.ratelimit)
     output_template, template_ext = os.path.splitext(args.output_template)
     preferformat = template_ext.strip('.') or args.preferformat
+    if args.subtitles_only:
+        if args.sublang not in ('fin', 'swe'):
+            logger.error('--subtitles-only requires --sublang fin or --sublang swe')
+            return RD_FAILED
+        preferformat = 'srt'
     title_formatter = TitleFormatter(output_template, args.output_na_placeholder)
     if args.xattrs and sys.platform in ['win32', 'cygwin']:
         logger.warning('--xattrs not supported on Windows')
@@ -648,6 +659,7 @@ def main(argv=sys.argv):
         create_dirs=args.create_dirs,
         xattr=args.xattrs,
         subtitle_delay_ms=args.subdelay,
+        subtitles_only=args.subtitles_only,
     )
 
     action = _parse_action(args)


### PR DESCRIPTION
Closes #340 

Adds a `--subtitles-only` flag for downloading only the subtitle file from a stream, without downloading video or audio. Must be combined with `--sublang 
  fin` or `--sublang swe`.
                                                                                                                                                            
Example:                                                  
yle-dl --sublang fin --subtitles-only https://areena.yle.fi/...

**Changes:**
- `DASHHLSBackend`: passes `-vn -an` to ffmpeg and maps only the subtitle stream when `--subtitles-only` is set; bypasses the ffprobe resume check since there is no video to compare against; uses direct SRT timestamp shifting (instead of the ffmpeg re-mux path) when combined with `--subdelay`              
- `WgetBackend`: returns success after downloading external subtitles, skipping the video download
- `_shift_srt_timestamps` moved from `WgetBackend` to `ExternalDownloader` so both backends can use it                                                    
- `IOContext`: new `subtitles_only` field                 
- README (fi/en/sv) updated      